### PR TITLE
Include render template assets in package builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dev = ["pytest>=8.2.0"]
 [project.scripts]
 committee = "committee_builder.cli:main"
 
+[tool.setuptools.package-data]
+committee_builder = ["render/*.css", "render/*.j2"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"


### PR DESCRIPTION
### Motivation
- The built package omitted runtime template and CSS files used by `committee_builder.pipeline.build_pipeline`, causing `committee build` to fail when installed from a built distribution.

### Description
- Add a `[tool.setuptools.package-data]` entry to `pyproject.toml` to include `render/*.css` and `render/*.j2` in the `committee_builder` package so templates and styles are present in built distributions.

### Testing
- Ran `pytest` which succeeded (`8 passed`); `black --check .` reported files that would be reformatted and thus failed the check; `flake8` was not available in the environment; attempting `python -m pip wheel .` to inspect build artifacts failed due to network/proxy issues preventing dependency resolution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19a2750f48320b471369d843d02e4)