### PR TITLE
Fix escaped inline assets in generated HTML output

### DIFF
--- a/committee_builder/render/template.html.j2
+++ b/committee_builder/render/template.html.j2
@@ -4,11 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ page_title | e }} - Committee History</title>
-  <style>{{ css }}</style>
+  <style>{{ css | safe }}</style>
 </head>
 <body>
   <div id="app"></div>
-  <script id="committee-data" type="application/json">{{ data_json }}</script>
-  <script>{{ app_js }}</script>
+  <script id="committee-data" type="application/json">{{ data_json | safe }}</script>
+  <script>{{ app_js | safe }}</script>
 </body>
 </html>

--- a/tests/test_output_html.py
+++ b/tests/test_output_html.py
@@ -38,3 +38,15 @@ def test_output_contains_inlined_assets_and_data(tmp_path: Path) -> None:
     assert '<script id="committee-data" type="application/json">' in text
     assert "Output Test" in text
     assert "timeline-item" in text
+
+
+def test_output_does_not_escape_inline_script_and_json(tmp_path: Path) -> None:
+    src = tmp_path / "source.yaml"
+    src.write_text(SAMPLE, encoding="utf-8")
+
+    out = build_html(src, output_path=None, overwrite=False)
+    text = out.read_text(encoding="utf-8")
+
+    assert "&#34;" not in text
+    assert "(() => {" in text
+    assert 'const root = document.getElementById("app");' in text


### PR DESCRIPTION
### Motivation
- Jinja autoescaping was applied to inlined assets, causing the embedded JSON and JavaScript to be HTML-escaped (e.g. `"` -> `&#34;`, `=>` -> `=&gt;`) and resulting in invalid JS in the generated standalone HTML and browser parse errors.

### Description
- Marked inlined CSS, the embedded JSON payload, and the JavaScript template content as safe in `committee_builder/render/template.html.j2` by using the `| safe` filter so they are emitted verbatim in the generated HTML.
- Added a regression test `test_output_does_not_escape_inline_script_and_json` in `tests/test_output_html.py` to assert that the built HTML does not contain escaped quote entities and that expected JS bootstrap code is present.

### Testing
- Ran `pytest -q` and all tests passed (`......... [100%]`).
- Ran `black --check .` which reported many repo-wide reformat suggestions unrelated to this change, and `black` was used to reformat the updated test file specifically (`black --check tests/test_output_html.py` passed after formatting).
- Ran `flake8 .` but the tool is not available in the environment (`command not found`), so linting could not be completed with `flake8`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19d447d548320adbda71849c1e2c3)