### PR TITLE
Fix Indico category title fallback and auth reporting

### DIFF
--- a/committee_builder/commands/sources.py
+++ b/committee_builder/commands/sources.py
@@ -15,6 +15,7 @@ import typer
 from committee_builder.indico.client import (
     IndicoContribution,
     IndicoDocument,
+    IndicoAuthError,
     fetch_category_title,
     fetch_meetings,
 )
@@ -233,12 +234,16 @@ def add_source_command(
     """Add or replace a source in the project config."""
     config_path = _normalize_config_path(config)
     base_url, category_id = _parse_category_url(category_url)
-    source_name = title or fetch_category_title(
-        base_url=base_url,
-        category_id=category_id,
-        api_key_env=api_key_env,
-        api_token_env=api_token_env,
-    )
+    try:
+        source_name = title or fetch_category_title(
+            base_url=base_url,
+            category_id=category_id,
+            api_key_env=api_key_env,
+            api_token_env=api_token_env,
+        )
+    except IndicoAuthError as exc:
+        logger.error("%s", exc)
+        raise
 
     current = load_indico_config(config_path)
     source_color = (
@@ -376,13 +381,23 @@ def generate_sources_command(
 
     generated_events: list[dict[str, object]] = []
     for selected_source in selected:
-        for meeting in fetch_meetings(
-            selected_source,
-            range_start,
-            range_end,
-            api_key_env=api_key_env,
-            api_token_env=api_token_env,
-        ):
+        try:
+            meetings = fetch_meetings(
+                selected_source,
+                range_start,
+                range_end,
+                api_key_env=api_key_env,
+                api_token_env=api_token_env,
+            )
+        except IndicoAuthError as exc:
+            logger.warning(
+                "Skipping source '%s': %s",
+                selected_source.name,
+                exc,
+            )
+            continue
+
+        for meeting in meetings:
             interesting_contributions = _contributions_with_documents(
                 meeting.contributions
             )

--- a/committee_builder/indico/client.py
+++ b/committee_builder/indico/client.py
@@ -22,6 +22,10 @@ from committee_builder.indico.credentials import normalize_base_url, resolve_sto
 logger = logging.getLogger(__name__)
 
 
+class IndicoAuthError(RuntimeError):
+    """Raised when an Indico request appears to require credentials."""
+
+
 @dataclass(frozen=True)
 class IndicoDocument:
     """Normalized document reference associated with an event or contribution."""
@@ -92,15 +96,50 @@ def fetch_meetings(
         len(payload.get("results", [])),
         len(payload.get("additionalInfo", {}).get("eventCategories", [])),
     )
-    meetings = [_normalize_record(record) for record in payload.get("results", [])]
-    return [
-        _hydrate_meeting_participants(
-            meeting,
+    if (
+        not payload.get("results")
+        and not payload.get("additionalInfo", {}).get("eventCategories", [])
+        and _auth_mode_for_base_url(source.base_url, api_key_env, api_token_env) is None
+        and _fetch_category_page_title(
+            base_url=source.base_url,
+            category_id=source.category_id,
             api_key_env=api_key_env,
             api_token_env=api_token_env,
         )
-        for meeting in meetings
-    ]
+        is None
+    ):
+        raise IndicoAuthError(
+            (
+                f"Category {source.category_id} at {source.base_url} did not return public "
+                "meeting data. Set INDICO_API_TOKEN/INDICO_API_KEY or store a project-local "
+                "credential with `committee indico api-key BASE_URL TOKEN`."
+            )
+        )
+    meetings = [_normalize_record(record) for record in payload.get("results", [])]
+    hydrated_meetings: list[IndicoMeeting] = []
+    for meeting in meetings:
+        try:
+            hydrated_meetings.append(
+                _hydrate_meeting_participants(
+                    meeting,
+                    api_key_env=api_key_env,
+                    api_token_env=api_token_env,
+                )
+            )
+        except IndicoAuthError:
+            raise
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code not in {401, 403}:
+                raise
+            logger.warning(
+                "Skipping agenda details for %s (%s) because Indico returned HTTP %s.",
+                meeting.title,
+                meeting.remote_id,
+                status_code,
+            )
+            hydrated_meetings.append(meeting)
+    return hydrated_meetings
 
 
 def fetch_category_title(
@@ -140,6 +179,15 @@ def fetch_category_title(
     if category_page_title:
         return category_page_title
 
+    if _auth_mode_for_base_url(base_url, api_key_env, api_token_env) is None:
+        raise IndicoAuthError(
+            (
+                f"No title returned for category {category_id} at {base_url}. "
+                "The category may require authentication. Set INDICO_API_TOKEN/INDICO_API_KEY "
+                "or store a project-local credential with "
+                "`committee indico api-key BASE_URL TOKEN`."
+            )
+        )
     raise RuntimeError(f"No title returned for category {category_id}.")
 
 
@@ -300,19 +348,22 @@ def _build_auth(
     api_token_env: str,
 ) -> dict[str, dict[str, str]]:
     base_url = _base_url_from_request_url(request_url)
+    auth_mode = _auth_mode_for_base_url(base_url, api_key_env, api_token_env)
     explicit_api_key = os.getenv(api_key_env)
     explicit_api_token = os.getenv(api_token_env)
-    stored_api_token = None
-    if not explicit_api_key and not explicit_api_token:
-        stored_api_token = resolve_stored_api_key(base_url)
+    stored_api_token = (
+        resolve_stored_api_key(base_url)
+        if not explicit_api_key and not explicit_api_token
+        else None
+    )
 
     api_key = explicit_api_key
     api_token = explicit_api_token or stored_api_token
-    if not api_key and not api_token:
+    if auth_mode is None:
         logger.debug("No Indico auth configured for base_url=%s", base_url)
         return {"params": {}, "headers": {}}
 
-    if api_key and api_token:
+    if auth_mode == "signed":
         logger.debug("Using signed Indico API auth for base_url=%s", base_url)
         timestamp = str(int(time.time()))
         signed_params = dict(params)
@@ -325,12 +376,34 @@ def _build_auth(
         )
         return {"params": signed_params, "headers": {}}
 
-    if api_key:
+    if auth_mode == "api_key":
         logger.debug("Using API key query auth for base_url=%s", base_url)
         return {"params": {"ak": api_key}, "headers": {}}
 
     logger.debug("Using bearer token auth for base_url=%s", base_url)
     return {"params": {}, "headers": {"Authorization": f"Bearer {api_token}"}}
+
+
+def _auth_mode_for_base_url(
+    base_url: str, api_key_env: str, api_token_env: str
+) -> str | None:
+    explicit_api_key = os.getenv(api_key_env)
+    explicit_api_token = os.getenv(api_token_env)
+    stored_api_token = (
+        resolve_stored_api_key(base_url)
+        if not explicit_api_key and not explicit_api_token
+        else None
+    )
+    api_key = explicit_api_key
+    api_token = explicit_api_token or stored_api_token
+
+    if api_key and api_token:
+        return "signed"
+    if api_key:
+        return "api_key"
+    if api_token:
+        return "bearer"
+    return None
 
 
 def _base_url_from_request_url(request_url: str) -> str:

--- a/tests/test_sources_cli.py
+++ b/tests/test_sources_cli.py
@@ -13,6 +13,7 @@ from committee_builder.cli import app
 from committee_builder.indico.client import (
     IndicoContribution,
     IndicoDocument,
+    IndicoAuthError,
     IndicoMeeting,
 )
 from committee_builder.indico import client as indico_client_module
@@ -158,6 +159,30 @@ def test_indico_add_uses_category_title_when_not_provided(
         )
         assert list_result.exit_code == 0
         assert "ATLAS: category=77, base_url=https://indico.example.com/indico, color=" in list_result.stdout
+
+
+def test_indico_add_logs_auth_error_for_protected_category(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    with runner.isolated_filesystem():
+        monkeypatch.setattr(
+            "committee_builder.commands.sources.fetch_category_title",
+            lambda **_kwargs: (_ for _ in ()).throw(IndicoAuthError("auth required")),
+        )
+
+        with caplog.at_level("ERROR"):
+            result = runner.invoke(
+                app,
+                [
+                    "indico",
+                    "add",
+                    "atlas",
+                    "https://indico.example.com/category/77/",
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert "auth required" in caplog.text
 
 
 def test_indico_add_normalizes_named_color() -> None:
@@ -655,6 +680,58 @@ def test_indico_generate_marks_meeting_interesting_when_only_agenda_documents_ex
         assert event["important"] is True
         assert "agenda.pdf" in rendered
         assert "short_label" not in event
+
+
+def test_indico_generate_logs_warning_and_skips_source_on_auth_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    with runner.isolated_filesystem():
+        project_path = Path("project.yaml")
+        project_path.write_text(BASE_PROJECT, encoding="utf-8")
+
+        config_path = Path("sources")
+        add_result = runner.invoke(
+            app,
+            [
+                "indico",
+                "add",
+                str(config_path),
+                "https://indico.example.com/category/11/",
+                "--title",
+                "atlas",
+            ],
+        )
+        assert add_result.exit_code == 0
+
+        monkeypatch.setattr(
+            "committee_builder.commands.sources.fetch_meetings",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                IndicoAuthError("auth required")
+            ),
+        )
+
+        output_path = Path("generated.yaml")
+        with caplog.at_level("WARNING"):
+            result = runner.invoke(
+                app,
+                [
+                    "indico",
+                    "generate",
+                    str(config_path),
+                    str(project_path),
+                    "--from",
+                    "2024-05-01",
+                    "--to",
+                    "2024-05-31",
+                    "--output",
+                    str(output_path),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "Skipping source 'atlas': auth required" in caplog.text
+        parsed = yaml.safe_load(output_path.read_text(encoding="utf-8"))
+        assert parsed["events"] == []
 
 
 def test_resolve_generate_paths_treats_missing_second_arg_as_output(


### PR DESCRIPTION
## Summary
- fix Indico category page title fallback parsing so `committee indico add` accepts both normal and mojibake `? Indico` title suffixes
- report auth-related category access failures clearly during `indico add` and warn-and-skip protected sources during `indico generate`
- add regression coverage for title fallback parsing and auth error handling in the source CLI tests

## Testing
- .\\.venv\\Scripts\\python.exe -m pytest tests\\test_sources_cli.py
- manual `uvx --from git+https://github.com/gordonwatts/time-page.git@issue/bad-title ...` verification for protected CERN Indico category access with and without `INDICO_API_TOKEN`

Fixes #13
