### PR TITLE
Use Indico contribution titles instead of filename guesses

### DIFF
--- a/committee_builder/commands/sources.py
+++ b/committee_builder/commands/sources.py
@@ -833,14 +833,15 @@ def _escape_markdown_table_cell(value: str) -> str:
 
 
 def _short_contribution_title(contribution: IndicoContribution) -> str:
-    fallback = re.sub(r"\s+", " ", contribution.title).strip()
-    if fallback:
-        return fallback
+    normalized_title = re.sub(r"\s+", " ", contribution.title).strip()
+    if normalized_title:
+        return normalized_title
 
-    source = contribution.documents[0].label if contribution.documents else contribution.title
+    if not contribution.documents:
+        return "Untitled talk"
+
+    source = contribution.documents[0].label
     shortened = _short_title_from_label(source, contribution.speaker_names)
-    if _looks_like_identifier_title(shortened):
-        return shortened or "Untitled talk"
     return shortened or "Untitled talk"
 
 

--- a/committee_builder/render/app.js.j2
+++ b/committee_builder/render/app.js.j2
@@ -162,9 +162,6 @@
       value = value.replace(pattern, "").trim();
     }
     value = value.replace(/\s+/g, " ").trim();
-    if (looksLikeIdentifierTitle(value)) {
-      return value || source || "Untitled talk";
-    }
     return value || source || "Untitled talk";
   }
 

--- a/tests/test_sources_cli.py
+++ b/tests/test_sources_cli.py
@@ -1256,6 +1256,12 @@ def test_short_contribution_title_falls_back_to_cleaned_filename() -> None:
     assert _short_contribution_title(contribution) == "Lossy Compression Studies In FTAG"
 
 
+def test_short_contribution_title_uses_placeholder_without_title_or_documents() -> None:
+    contribution = IndicoContribution(title="", speaker_names=["Romain Bouquet"], documents=[])
+
+    assert _short_contribution_title(contribution) == "Untitled talk"
+
+
 def test_build_document_link_labels_uses_talk_for_single_upload() -> None:
     labels = _build_document_link_labels(
         [IndicoDocument(label="Very long filename.pdf", url="https://example.org/slides.pdf")]


### PR DESCRIPTION
## Summary
- prefer the actual Indico contribution title when building imported talk summaries
- use the same talk title in the rendered document grouping UI instead of a cleaned filename guess
- cover the new fallback behavior with focused tests

Fixes #15