### PR TITLE
Preserve timeline selection and scroll position

### DIFF
--- a/committee_builder/render/app.js.j2
+++ b/committee_builder/render/app.js.j2
@@ -11,7 +11,12 @@
     return;
   }
 
-  const state = { query: "", selectedId: data.events?.[0]?.id ?? null };
+  const storageKey = `committee-history:${window.location.pathname}:${data.committee?.name || "default"}`;
+  const state = {
+    query: "",
+    selectedId: data.events?.[0]?.id ?? null,
+    timelineScrollTop: 0,
+  };
   const namedPalette = {
     sky: { background: "#e0f2fe", color: "#075985", border: "#bae6fd" },
     emerald: { background: "#d1fae5", color: "#065f46", border: "#a7f3d0" },
@@ -223,7 +228,35 @@
     return target.isContentEditable || tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT";
   }
 
+  function loadState() {
+    try {
+      const raw = window.sessionStorage.getItem(storageKey);
+      if (!raw) return;
+      const saved = JSON.parse(raw);
+      if (typeof saved.query === "string") state.query = saved.query;
+      if (typeof saved.selectedId === "string" && saved.selectedId) state.selectedId = saved.selectedId;
+      if (Number.isFinite(saved.timelineScrollTop)) state.timelineScrollTop = saved.timelineScrollTop;
+    } catch {}
+  }
+
+  function persistState() {
+    try {
+      window.sessionStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          query: state.query,
+          selectedId: state.selectedId,
+          timelineScrollTop: state.timelineScrollTop,
+        }),
+      );
+    } catch {}
+  }
+
   function render() {
+    const previousTimeline = root.querySelector("#timeline");
+    if (previousTimeline) {
+      state.timelineScrollTop = previousTimeline.scrollTop;
+    }
     const activeElement = document.activeElement;
     const searchWasFocused = activeElement?.id === "search";
     const searchSelectionStart = searchWasFocused ? activeElement.selectionStart : null;
@@ -338,21 +371,43 @@
     }
     timelineHtml += "</div>";
     timeline.innerHTML = timelineHtml;
+    timeline.scrollTop = state.timelineScrollTop;
 
     const search = root.querySelector("#search");
-    search?.addEventListener("input", (ev) => { state.query = ev.target.value; render(); });
+    search?.addEventListener("input", (ev) => {
+      state.query = ev.target.value;
+      persistState();
+      render();
+    });
     if (searchWasFocused && search) {
       search.focus();
       if (searchSelectionStart !== null && searchSelectionEnd !== null) {
         search.setSelectionRange(searchSelectionStart, searchSelectionEnd);
       }
     }
+    timeline.addEventListener("scroll", () => {
+      state.timelineScrollTop = timeline.scrollTop;
+      persistState();
+    }, { passive: true });
     timeline.querySelectorAll("[data-event-id]").forEach((el) => {
-      el.addEventListener("click", () => { state.selectedId = el.getAttribute("data-event-id"); render(); });
+      el.addEventListener("click", () => {
+        state.selectedId = el.getAttribute("data-event-id");
+        state.timelineScrollTop = timeline.scrollTop;
+        persistState();
+        render();
+      });
     });
+    persistState();
   }
 
+  loadState();
   render();
+
+  window.addEventListener("pagehide", () => {
+    const timeline = root.querySelector("#timeline");
+    if (timeline) state.timelineScrollTop = timeline.scrollTop;
+    persistState();
+  });
 
   document.addEventListener("keydown", (event) => {
     if (event.key !== "/" || event.ctrlKey || event.metaKey || event.altKey) return;

--- a/tests/test_timeline_state_html.py
+++ b/tests/test_timeline_state_html.py
@@ -1,0 +1,38 @@
+"""Tests for persisted timeline state wiring in generated HTML."""
+
+from pathlib import Path
+
+from committee_builder.pipeline.build_pipeline import build_html
+
+
+SAMPLE = """
+schema_version: "1.0"
+committee:
+  name: "Timeline State Test"
+  start_date: "2023-01-01"
+event_type_styles:
+  meeting: {label: "Meeting", color: "sky"}
+  report: {label: "Report", color: "emerald"}
+  decision: {label: "Decision", color: "rose"}
+  milestone: {label: "Milestone", color: "amber"}
+  external: {label: "External", color: "violet"}
+events:
+  - id: "evt-1"
+    type: "meeting"
+    title: "Kickoff"
+    date: "2023-01-10"
+    important: true
+    summary_md: "Intro"
+"""
+
+
+def test_output_includes_timeline_state_persistence_hooks(tmp_path: Path) -> None:
+    src = tmp_path / "source.yaml"
+    src.write_text(SAMPLE, encoding="utf-8")
+
+    out = build_html(src, output_path=None, overwrite=False)
+    text = out.read_text(encoding="utf-8")
+
+    assert "window.sessionStorage.getItem(storageKey)" in text
+    assert "timelineScrollTop: state.timelineScrollTop" in text
+    assert 'window.addEventListener("pagehide"' in text


### PR DESCRIPTION
## Summary
- persist the selected event, search query, and timeline scroll offset in session storage
- restore the timeline scroll position after rerenders so item selection does not jump back to the top
- persist state on page hide so browser Back can restore the prior context

Fixes #16