### PR TITLE
Move the timeline above details on narrow screens

### DIFF
--- a/committee_builder/render/styles.css
+++ b/committee_builder/render/styles.css
@@ -76,8 +76,21 @@ h6 { margin: 0 0 8px; font-size: 0.8rem; color: var(--muted); text-transform: up
 .error { max-width: 820px; margin: 24px auto; border: 1px solid #fecaca; background: #fee2e2; color: #991b1b; border-radius: 12px; padding: 16px; }
 @media (max-width: 1024px) {
   .hero { flex-direction: column; align-items: stretch; }
-  .split { grid-template-columns: 1fr; }
+  .split {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "timeline"
+      "detail";
+  }
   .panel { height: auto; max-height: 72vh; }
+  .timeline {
+    grid-area: timeline;
+    max-height: min(24rem, 46vh);
+  }
+  .detail {
+    grid-area: detail;
+    max-height: none;
+  }
 }
 @media (max-width: 720px) {
   .page { padding: 16px; }

--- a/tests/test_mobile_layout_html.py
+++ b/tests/test_mobile_layout_html.py
@@ -1,0 +1,39 @@
+"""Tests for responsive stacked timeline layout in generated HTML."""
+
+from pathlib import Path
+
+from committee_builder.pipeline.build_pipeline import build_html
+
+
+SAMPLE = """
+schema_version: "1.0"
+committee:
+  name: "Responsive Layout Test"
+  start_date: "2023-01-01"
+event_type_styles:
+  meeting: {label: "Meeting", color: "sky"}
+  report: {label: "Report", color: "emerald"}
+  decision: {label: "Decision", color: "rose"}
+  milestone: {label: "Milestone", color: "amber"}
+  external: {label: "External", color: "violet"}
+events:
+  - id: "evt-1"
+    type: "meeting"
+    title: "Kickoff"
+    date: "2023-01-10"
+    important: true
+    summary_md: "Intro"
+"""
+
+
+def test_output_includes_mobile_timeline_first_layout(tmp_path: Path) -> None:
+    src = tmp_path / "source.yaml"
+    src.write_text(SAMPLE, encoding="utf-8")
+
+    out = build_html(src, output_path=None, overwrite=False)
+    text = out.read_text(encoding="utf-8")
+
+    assert 'grid-template-areas:' in text
+    assert '"timeline"' in text
+    assert '.timeline {' in text
+    assert 'max-height: min(24rem, 46vh);' in text


### PR DESCRIPTION
## Summary
- stack the timeline above the selected meeting panel once the layout collapses to one column
- constrain the mobile timeline height so it scrolls independently and leaves room for the selected meeting details below
- cover the responsive layout hooks in generated HTML tests

Fixes #6