### PR TITLE
Add Indico title match filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ committee build data/committee.history.yaml --output dist/committee-history.html
 - `committee init PATH [--force]`
 - `committee import-csv` (placeholder)
 - `committee import-md` (placeholder)
-- `committee indico add CONFIG CATEGORY_URL [--title TITLE] [--color COLOR] [--api-key-env ENV] [--api-token-env ENV]`
+- `committee indico add CONFIG CATEGORY_URL [--title TITLE] [--title-match PATTERN] [--color COLOR] [--api-key-env ENV] [--api-token-env ENV]`
 - `committee indico list CONFIG`
 - `committee indico remove CONFIG NAME`
 - `committee indico generate CONFIG PROJECT_YAML --from YYYY-MM-DD --to YYYY-MM-DD [--api-key-env ENV] [--api-token-env ENV] [--output PATH]`
@@ -111,6 +111,13 @@ committee indico add cern https://indico.example.org/category/1234/ --title cern
 ```
 
 If `--color` is omitted, the CLI assigns a unique pale hex color automatically. Named CSS colors and hex values are normalized to stored `#RRGGBB` category colors.
+
+To keep only meetings whose titles match a case-insensitive regular expression, add one or more `--title-match` values. Repeat the command to accumulate filters on the same source:
+
+```bash
+committee indico add cern https://indico.example.org/category/1234/ --title-match LUP
+committee indico add cern https://indico.example.org/category/1234/ --title-match Plenary
+```
 
 Generate meeting events into a new YAML file:
 

--- a/committee_builder/commands/sources.py
+++ b/committee_builder/commands/sources.py
@@ -230,6 +230,14 @@ def add_source_command(
         "--color",
         help="Optional feed color. Accepts hex (#RRGGBB or #RGB) or CSS color names.",
     ),
+    title_match: list[str] | None = typer.Option(
+        None,
+        "--title-match",
+        help=(
+            "Optional case-insensitive regex used to keep meetings by title. "
+            "Repeat to add multiple patterns."
+        ),
+    ),
 ) -> None:
     """Add or replace a source in the project config."""
     config_path = _normalize_config_path(config)
@@ -246,10 +254,20 @@ def add_source_command(
         raise
 
     current = load_indico_config(config_path)
+    current_source = next(
+        (source for source in current.sources if source.name == source_name),
+        None,
+    )
     source_color = (
         _normalize_source_color(color)
         if color is not None
+        else current_source.color
+        if current_source is not None
         else _assign_unique_source_color(current.sources)
+    )
+    title_matches = _merge_title_matches(
+        current_source.title_matches if current_source is not None else [],
+        _normalize_title_match_patterns(title_match or []),
     )
     filtered_sources = [
         source for source in current.sources if source.name != source_name
@@ -260,6 +278,7 @@ def add_source_command(
             category_id=category_id,
             base_url=base_url,
             color=source_color,
+            title_matches=title_matches,
         )
     )
     save_indico_config(
@@ -282,8 +301,14 @@ def list_sources_command(
         return
 
     for source in sorted(current.sources, key=lambda item: item.name):
+        match_summary = (
+            f", title_matches=[{', '.join(source.title_matches)}]"
+            if source.title_matches
+            else ""
+        )
         typer.echo(
-            f"{source.name}: category={source.category_id}, base_url={source.base_url}, color={source.color}"
+            f"{source.name}: category={source.category_id}, base_url={source.base_url}, "
+            f"color={source.color}{match_summary}"
         )
 
 
@@ -390,12 +415,20 @@ def generate_sources_command(
                 api_token_env=api_token_env,
             )
         except IndicoAuthError as exc:
-            logger.warning(
-                "Skipping source '%s': %s",
-                selected_source.name,
-                exc,
+                logger.warning(
+                    "Skipping source '%s': %s",
+                    selected_source.name,
+                    exc,
+                )
+                continue
+
+        meetings = [
+            meeting
+            for meeting in meetings
+            if _meeting_matches_title_patterns(
+                meeting.title, selected_source.title_matches
             )
-            continue
+        ]
 
         for meeting in meetings:
             interesting_contributions = _contributions_with_documents(
@@ -702,6 +735,47 @@ def _select_sources(config: IndicoConfig, names: list[str]) -> list[IndicoSource
     if missing_sources:
         raise typer.BadParameter(f"Unknown source(s): {', '.join(missing_sources)}")
     return [source_lookup[name] for name in names]
+
+
+def _normalize_title_match_patterns(values: list[str]) -> list[str]:
+    patterns: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = re.sub(r"\s+", " ", value).strip()
+        if not normalized:
+            continue
+        try:
+            re.compile(normalized, flags=re.IGNORECASE)
+        except re.error as exc:
+            raise typer.BadParameter(
+                f"Invalid title match pattern '{value}': {exc}"
+            ) from exc
+        folded = normalized.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        patterns.append(normalized)
+    return patterns
+
+
+def _merge_title_matches(existing: list[str], additions: list[str]) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for value in [*existing, *additions]:
+        folded = value.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        merged.append(value)
+    return merged
+
+
+def _meeting_matches_title_patterns(title: str, title_patterns: list[str]) -> bool:
+    if not title_patterns:
+        return True
+    return any(
+        re.search(pattern, title, flags=re.IGNORECASE) for pattern in title_patterns
+    )
 
 
 def _build_contribution_table(contributions: list[IndicoContribution]) -> str:

--- a/committee_builder/indico/config.py
+++ b/committee_builder/indico/config.py
@@ -19,6 +19,7 @@ class IndicoSource(BaseModel):
     category_id: int
     base_url: str = Field(min_length=1)
     color: str = Field(min_length=1)
+    title_matches: list[str] = Field(default_factory=list)
 
 
 class IndicoConfig(BaseModel):
@@ -42,4 +43,7 @@ def save_indico_config(path: Path, config: IndicoConfig) -> None:
     """Persist config to disk in a deterministic order."""
     serialized = config.model_dump(mode="json")
     serialized["sources"] = sorted(serialized["sources"], key=lambda item: item["name"])
+    for source in serialized["sources"]:
+        if not source.get("title_matches"):
+            source.pop("title_matches", None)
     write_yaml(path, serialized)

--- a/tests/test_sources_cli.py
+++ b/tests/test_sources_cli.py
@@ -25,6 +25,7 @@ from committee_builder.commands.sources import (
     _resolve_generate_paths,
     _short_contribution_title,
 )
+from committee_builder.indico.config import load_indico_config
 from committee_builder.indico.credentials import api_key_env_name
 
 runner = CliRunner()
@@ -77,6 +78,48 @@ def test_indico_add_list_remove() -> None:
         empty_result = runner.invoke(app, ["indico", "list", str(config)])
         assert empty_result.exit_code == 0
         assert "No sources configured." in empty_result.stdout
+
+
+def test_indico_add_accumulates_title_matches() -> None:
+    with runner.isolated_filesystem():
+        config = Path("project")
+
+        first_result = runner.invoke(
+            app,
+            [
+                "indico",
+                "add",
+                str(config),
+                "https://indico.example.com/category/42/",
+                "--title",
+                "cern",
+                "--title-match",
+                "LUP",
+            ],
+        )
+        second_result = runner.invoke(
+            app,
+            [
+                "indico",
+                "add",
+                str(config),
+                "https://indico.example.com/category/42/",
+                "--title",
+                "cern",
+                "--title-match",
+                "Plenary",
+            ],
+        )
+
+        assert first_result.exit_code == 0
+        assert second_result.exit_code == 0
+
+        config_data = load_indico_config(config.with_suffix(".yaml"))
+        assert config_data.sources[0].title_matches == ["LUP", "Plenary"]
+
+        list_result = runner.invoke(app, ["indico", "list", str(config)])
+        assert list_result.exit_code == 0
+        assert "title_matches=[LUP, Plenary]" in list_result.stdout
 
 
 def test_indico_api_key_creates_and_updates_local_dotenv() -> None:
@@ -347,6 +390,104 @@ def test_indico_generate_merges_imported_meetings(
         assert "slides.pdf" in rendered
         assert "https://indico.example.com/files/slides.pdf" in rendered
         assert "Event Link" not in rendered
+
+
+def test_indico_generate_filters_meetings_by_title_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with runner.isolated_filesystem():
+        project_path = Path("project.yaml")
+        project_path.write_text(BASE_PROJECT, encoding="utf-8")
+
+        config_path = Path("sources")
+        add_result = runner.invoke(
+            app,
+            [
+                "indico",
+                "add",
+                str(config_path),
+                "https://indico.example.com/category/11/",
+                "--title",
+                "atlas",
+                "--title-match",
+                "LUP",
+            ],
+        )
+        assert add_result.exit_code == 0
+
+        update_result = runner.invoke(
+            app,
+            [
+                "indico",
+                "add",
+                str(config_path),
+                "https://indico.example.com/category/11/",
+                "--title",
+                "atlas",
+                "--title-match",
+                "Plenary",
+            ],
+        )
+        assert update_result.exit_code == 0
+
+        def fake_fetch(*_args: object, **_kwargs: object) -> list[IndicoMeeting]:
+            return [
+                IndicoMeeting(
+                    remote_id="1001",
+                    title="LUP Working Meeting",
+                    start_datetime=datetime(2024, 5, 10, 9, 30),
+                    description="Imported agenda",
+                    participants=[],
+                    documents=[],
+                    url=None,
+                ),
+                IndicoMeeting(
+                    remote_id="1002",
+                    title="Budget Review",
+                    start_datetime=datetime(2024, 5, 11, 9, 30),
+                    description="Imported agenda",
+                    participants=[],
+                    documents=[],
+                    url=None,
+                ),
+                IndicoMeeting(
+                    remote_id="1003",
+                    title="Plenary Session",
+                    start_datetime=datetime(2024, 5, 12, 9, 30),
+                    description="Imported agenda",
+                    participants=[],
+                    documents=[],
+                    url=None,
+                ),
+            ]
+
+        monkeypatch.setattr(
+            "committee_builder.commands.sources.fetch_meetings", fake_fetch
+        )
+
+        output_path = Path("filtered.yaml")
+        result = runner.invoke(
+            app,
+            [
+                "indico",
+                "generate",
+                str(config_path),
+                str(project_path),
+                "--from",
+                "2024-05-01",
+                "--to",
+                "2024-05-31",
+                "--output",
+                str(output_path),
+            ],
+        )
+        assert result.exit_code == 0
+
+        parsed = yaml.safe_load(output_path.read_text(encoding="utf-8"))
+        assert [event["title"] for event in parsed["events"]] == [
+            "LUP Working Meeting",
+            "Plenary Session",
+        ]
 
 
 def test_indico_generate_converts_html_descriptions_to_markdown(


### PR DESCRIPTION
Fixes #12

Implements issue #12 by adding repeatable source-level title match patterns for Indico categories. Repeated \\indico add\\ commands now accumulate patterns instead of replacing them, and generated meetings are filtered by matching titles.

Validation: .\\.venv\\Scripts\\python.exe -m pytest (66 passed, 1 skipped).