### PR TITLE
Remove obsolete optional indico dummy test

### DIFF
--- a/tests/test_sources_cli.py
+++ b/tests/test_sources_cli.py
@@ -1562,8 +1562,5 @@ def test_compact_unique_labels_reverts_colliding_word_boundary_rollbacks() -> No
     assert labels == ["Alpha beta one file.", "Alpha beta one note.", "Gamma delta report"]
 
 
-def test_indico_client_dummy_without_dependency() -> None:
-    """Dummy test to ensure environments without indico-client still pass test suite."""
-    pytest.importorskip("indico")
 
 


### PR DESCRIPTION
## Summary
- remove the obsolete skipped indico dummy test from the CLI test suite
- keep the suite focused on repository behavior that is still exercised

## Testing
- C:\\Users\\gordo\\Code\\llms\\time-page\\.venv\\Scripts\\python.exe -m pytest

Fixes #23