### PR TITLE
Refactor schema and Indico config into unified ProjectFile YAML model

### DIFF
--- a/committee_builder/commands/init.py
+++ b/committee_builder/commands/init.py
@@ -14,13 +14,15 @@ logger = logging.getLogger(__name__)
 
 STARTER_DOC = {
     "schema_version": "1.0",
-    "committee": {
+    "metadata": {
         "name": "Committee Name",
         "subtitle": "Optional subtitle",
         "description_md": "Optional markdown description.",
+        "notes_md": "Optional committee notes in markdown.",
+    },
+    "date_window": {
         "start_date": "2023-01-01",
         "end_date": "2024-12-31",
-        "notes_md": "Optional committee notes in markdown.",
     },
     "event_type_styles": {
         "meeting": {"label": "Meeting", "color": "sky"},

--- a/committee_builder/commands/sources.py
+++ b/committee_builder/commands/sources.py
@@ -19,20 +19,18 @@ from committee_builder.indico.client import (
     fetch_category_title,
     fetch_meetings,
 )
-from committee_builder.indico.config import (
-    IndicoConfig,
-    IndicoSource,
-    load_indico_config,
-    save_indico_config,
-)
 from committee_builder.indico.credentials import normalize_base_url, store_api_key
 from committee_builder.indico.markdown import html_to_markdown
-from committee_builder.io.yaml_io import write_yaml
+from committee_builder.io.yaml_io import (
+    load_project_file,
+    save_project_file,
+    write_yaml,
+)
 from committee_builder.pipeline.validate_pipeline import (
     PipelineValidationResult,
     validate_yaml,
 )
-from committee_builder.schema.models import CommitteeHistory
+from committee_builder.schema.models import IndicoSource, ProjectFile
 from committee_builder.schema.validators import validate_semantics
 
 logger = logging.getLogger(__name__)
@@ -261,17 +259,23 @@ def add_source_command(
         logger.error("%s", exc)
         raise
 
-    current = load_indico_config(config_path)
+    current = _load_or_init_project(config_path)
     current_source = next(
-        (source for source in current.sources if source.name == source_name),
+        (
+            source
+            for source in current.indico_category_sources
+            if source.name == source_name
+        ),
         None,
     )
     source_color = (
         _normalize_source_color(color)
         if color is not None
-        else current_source.color
-        if current_source is not None
-        else _assign_unique_source_color(current.sources)
+        else (
+            current_source.color
+            if current_source is not None
+            else _assign_unique_source_color(current.indico_category_sources)
+        )
     )
     title_matches = _merge_title_matches(
         current_source.title_matches if current_source is not None else [],
@@ -285,7 +289,9 @@ def add_source_command(
         ),
     )
     filtered_sources = [
-        source for source in current.sources if source.name != source_name
+        source
+        for source in current.indico_category_sources
+        if source.name != source_name
     ]
     filtered_sources.append(
         IndicoSource(
@@ -297,9 +303,15 @@ def add_source_command(
             title_exclude_patterns=title_exclude_patterns,
         )
     )
-    save_indico_config(
+    save_project_file(
         config_path,
-        IndicoConfig(version=current.version, sources=filtered_sources),
+        current.model_copy(
+            update={
+                "indico_category_sources": sorted(
+                    filtered_sources, key=lambda source: source.name.casefold()
+                )
+            }
+        ),
     )
     logger.info("Saved source '%s' in %s", source_name, config_path)
 
@@ -311,12 +323,14 @@ def list_sources_command(
 ) -> None:
     """List all configured sources."""
     config_path = _normalize_config_path(config)
-    current = load_indico_config(config_path)
-    if not current.sources:
+    current = _load_or_init_project(config_path)
+    if not current.indico_category_sources:
         typer.echo("No sources configured.")
         return
 
-    for source in sorted(current.sources, key=lambda item: item.name):
+    for source in sorted(
+        current.indico_category_sources, key=lambda item: item.name.casefold()
+    ):
         match_summary = (
             f", title_matches=[{', '.join(source.title_matches)}]"
             if source.title_matches
@@ -354,12 +368,23 @@ def remove_source_command(
 ) -> None:
     """Remove a source by name."""
     config_path = _normalize_config_path(config)
-    current = load_indico_config(config_path)
-    filtered = [source for source in current.sources if source.name != name]
-    if len(filtered) == len(current.sources):
+    current = _load_or_init_project(config_path)
+    filtered = [
+        source for source in current.indico_category_sources if source.name != name
+    ]
+    if len(filtered) == len(current.indico_category_sources):
         raise typer.BadParameter(f"Source not found: {name}")
 
-    save_indico_config(config_path, IndicoConfig(version=current.version, sources=filtered))
+    save_project_file(
+        config_path,
+        current.model_copy(
+            update={
+                "indico_category_sources": sorted(
+                    filtered, key=lambda source: source.name.casefold()
+                )
+            }
+        ),
+    )
     logger.info("Removed source '%s' from %s", name, config_path)
 
 
@@ -408,8 +433,8 @@ def generate_sources_command(
     range_start, range_end = _resolve_range(
         parsed_from, parsed_to, past_weeks, future_weeks
     )
-    config_data = load_indico_config(config_path)
-    selected = _select_sources(config_data, source)
+    project = _load_or_init_project(config_path)
+    selected = _select_sources(project, source)
     generate_paths = _resolve_generate_paths(
         config_path=config_path,
         project_yaml=project_yaml,
@@ -418,7 +443,6 @@ def generate_sources_command(
     )
     validated = _load_history(
         config_path=config_path,
-        config_data=config_data,
         project_yaml=generate_paths.project_yaml,
         range_start=range_start,
         range_end=range_end,
@@ -436,12 +460,12 @@ def generate_sources_command(
                 api_token_env=api_token_env,
             )
         except IndicoAuthError as exc:
-                logger.warning(
-                    "Skipping source '%s': %s",
-                    selected_source.name,
-                    exc,
-                )
-                continue
+            logger.warning(
+                "Skipping source '%s': %s",
+                selected_source.name,
+                exc,
+            )
+            continue
 
         meetings = [
             meeting
@@ -452,12 +476,16 @@ def generate_sources_command(
         ]
 
         for meeting in meetings:
-            if _meeting_matches_title_exclusions(meeting.title, selected_source.title_exclude_patterns):
+            if _meeting_matches_title_exclusions(
+                meeting.title, selected_source.title_exclude_patterns
+            ):
                 continue
             interesting_contributions = _contributions_with_documents(
                 meeting.contributions
             )
-            is_interesting_meeting = bool(meeting.documents or interesting_contributions)
+            is_interesting_meeting = bool(
+                meeting.documents or interesting_contributions
+            )
             summary_md = (
                 html_to_markdown(meeting.description, base_url=selected_source.base_url)
                 or ""
@@ -544,12 +572,22 @@ def generate_sources_command(
     )
     output_payload = {
         "schema_version": validated.history.schema_version,
-        "committee": validated.history.committee.model_dump(mode="json"),
+        "metadata": validated.history.metadata.model_dump(mode="json"),
+        "date_window": validated.history.date_window.model_dump(mode="json"),
         "event_type_styles": {
             event_type.value: event_style.model_dump(mode="json")
             for event_type, event_style in event_styles.items()
         },
         "events": [merged_events[event_id] for event_id in sorted(merged_events)],
+        "indico_meeting_source": (
+            validated.history.indico_meeting_source.model_dump(mode="json")
+            if validated.history.indico_meeting_source is not None
+            else None
+        ),
+        "indico_category_sources": [
+            source_item.model_dump(mode="json")
+            for source_item in validated.history.indico_category_sources
+        ],
     }
     write_yaml(output_path, output_payload)
     logger.info(
@@ -566,15 +604,21 @@ def _resolve_generate_paths(
     inferred_project = config_path.with_name(f"{config_path.stem}-project.yaml")
 
     if output_option is not None and output_arg is not None:
-        raise typer.BadParameter("Use either positional OUTPUT_YAML or --output, not both.")
+        raise typer.BadParameter(
+            "Use either positional OUTPUT_YAML or --output, not both."
+        )
 
     if project_yaml is None:
         if inferred_project.exists():
-            return GeneratePaths(project_yaml=inferred_project, output_path=output_option)
+            return GeneratePaths(
+                project_yaml=inferred_project, output_path=output_option
+            )
         return GeneratePaths(project_yaml=None, output_path=output_option)
 
     if project_yaml.exists():
-        return GeneratePaths(project_yaml=project_yaml, output_path=output_arg or output_option)
+        return GeneratePaths(
+            project_yaml=project_yaml, output_path=output_arg or output_option
+        )
 
     if inferred_project.exists():
         return GeneratePaths(project_yaml=inferred_project, output_path=project_yaml)
@@ -587,7 +631,6 @@ def _resolve_generate_paths(
 
 def _load_history(
     config_path: Path,
-    config_data: IndicoConfig,
     project_yaml: Path | None,
     range_start: date,
     range_end: date,
@@ -595,16 +638,18 @@ def _load_history(
     if project_yaml is not None:
         return validate_yaml(project_yaml)
 
-    committee_name = (
-        config_data.sources[0].name if len(config_data.sources) == 1 else config_path.stem
-    )
-    history = CommitteeHistory.model_validate(
+    if config_path.exists():
+        return validate_yaml(config_path)
+
+    history = ProjectFile.model_validate(
         {
             "schema_version": "1.0",
-            "committee": {
-                "name": committee_name,
+            "metadata": {
+                "name": config_path.stem,
                 "subtitle": "Imported Indico meetings",
                 "description_md": f"Generated from Indico source config `{config_path.name}`.",
+            },
+            "date_window": {
                 "start_date": range_start.isoformat(),
                 "end_date": range_end.isoformat(),
             },
@@ -741,11 +786,11 @@ def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:
     return "#{:02x}{:02x}{:02x}".format(*rgb)
 
 
-def _blend_rgb(rgb: tuple[int, int, int], weight_to_white: float) -> tuple[int, int, int]:
+def _blend_rgb(
+    rgb: tuple[int, int, int], weight_to_white: float
+) -> tuple[int, int, int]:
     clamped_weight = max(0.0, min(1.0, weight_to_white))
-    return tuple(
-        round(channel + (255 - channel) * clamped_weight) for channel in rgb
-    )
+    return tuple(round(channel + (255 - channel) * clamped_weight) for channel in rgb)
 
 
 def _resolve_range(
@@ -790,19 +835,39 @@ def _parse_iso_date(value: str | None, option_name: str) -> date | None:
         raise typer.BadParameter(f"Invalid date for {option_name}: {value}") from exc
 
 
-def _select_sources(config: IndicoConfig, names: list[str]) -> list[IndicoSource]:
-    if not config.sources:
+def _select_sources(project: ProjectFile, names: list[str]) -> list[IndicoSource]:
+    if not project.indico_category_sources:
         raise typer.BadParameter(
             "No sources configured. Run `committee indico add` first."
         )
     if not names:
-        return config.sources
+        return project.indico_category_sources
 
-    source_lookup = {source.name: source for source in config.sources}
+    source_lookup = {source.name: source for source in project.indico_category_sources}
     missing_sources = sorted(name for name in names if name not in source_lookup)
     if missing_sources:
         raise typer.BadParameter(f"Unknown source(s): {', '.join(missing_sources)}")
     return [source_lookup[name] for name in names]
+
+
+def _load_or_init_project(config_path: Path) -> ProjectFile:
+    if config_path.exists():
+        return load_project_file(config_path)
+    return _build_default_project(config_path.stem)
+
+
+def _build_default_project(project_name: str) -> ProjectFile:
+    today = date.today()
+    return ProjectFile.model_validate(
+        {
+            "schema_version": "1.0",
+            "metadata": {"name": project_name},
+            "date_window": {"start_date": today.isoformat(), "end_date": None},
+            "event_type_styles": DEFAULT_EVENT_TYPE_STYLES,
+            "events": [],
+            "indico_category_sources": [],
+        }
+    )
 
 
 def _meeting_matches_title_patterns(title: str, title_patterns: list[str]) -> bool:
@@ -822,12 +887,16 @@ def _build_contribution_table(contributions: list[IndicoContribution]) -> str:
         "| --- | --- | --- |",
     ]
     for contribution in sorted(contributions, key=lambda item: item.sort_key):
-        authors = ", ".join(contribution.speaker_names) if contribution.speaker_names else "-"
+        authors = (
+            ", ".join(contribution.speaker_names) if contribution.speaker_names else "-"
+        )
         if contribution.documents:
             document_labels = _build_document_link_labels(contribution.documents)
             documents = "<br>".join(
                 f"• [{_escape_markdown_table_cell(label)}]({document.url})"
-                for document, label in zip(contribution.documents, document_labels, strict=True)
+                for document, label in zip(
+                    contribution.documents, document_labels, strict=True
+                )
             )
         else:
             documents = "-"
@@ -835,7 +904,9 @@ def _build_contribution_table(contributions: list[IndicoContribution]) -> str:
             "| "
             + " | ".join(
                 [
-                    _escape_markdown_table_cell(_short_contribution_title(contribution)),
+                    _escape_markdown_table_cell(
+                        _short_contribution_title(contribution)
+                    ),
                     _escape_markdown_table_cell(authors),
                     documents.replace("|", "\\|"),
                 ]
@@ -866,19 +937,17 @@ def _compact_unique_labels(labels: list[str], *, initial_width: int = 20) -> lis
     minimum_width = min(initial_width, maximum_width)
 
     for width in range(minimum_width, maximum_width + 1):
-        shortened = [label if len(label) <= width else label[:width] for label in labels]
+        shortened = [
+            label if len(label) <= width else label[:width] for label in labels
+        ]
         if len(set(shortened)) != len(shortened):
             continue
 
-        rolled_back = [
-            _roll_back_to_word_boundary(label, width) for label in labels
-        ]
+        rolled_back = [_roll_back_to_word_boundary(label, width) for label in labels]
         if len(set(rolled_back)) == len(rolled_back):
             return rolled_back
 
-        duplicates = {
-            value for value in rolled_back if rolled_back.count(value) > 1
-        }
+        duplicates = {value for value in rolled_back if rolled_back.count(value) > 1}
         return [
             shortened[index] if value in duplicates else value
             for index, value in enumerate(rolled_back)
@@ -907,9 +976,7 @@ def _roll_back_to_word_boundary(value: str, width: int) -> str:
 def _contributions_with_documents(
     contributions: list[IndicoContribution],
 ) -> list[IndicoContribution]:
-    return [
-        contribution for contribution in contributions if contribution.documents
-    ]
+    return [contribution for contribution in contributions if contribution.documents]
 
 
 def _build_meeting_short_label(

--- a/committee_builder/indico/config.py
+++ b/committee_builder/indico/config.py
@@ -1,30 +1,18 @@
-"""Models and persistence helpers for Indico source configuration."""
+"""Compatibility helpers for Indico configuration stored in project YAML."""
 
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from committee_builder.io.yaml_io import read_yaml, write_yaml
-
-
-class IndicoSource(BaseModel):
-    """Single configured Indico category source."""
-
-    # Ignore legacy per-source credential fields if present in existing files.
-    model_config = ConfigDict(extra="ignore")
-
-    name: str = Field(min_length=1)
-    category_id: int
-    base_url: str = Field(min_length=1)
-    color: str = Field(min_length=1)
-    title_matches: list[str] = Field(default_factory=list)
-    title_exclude_patterns: list[str] = Field(default_factory=list)
+from committee_builder.io.yaml_io import load_project_file, save_project_file
+from committee_builder.schema.models import IndicoSource, ProjectFile
 
 
 class IndicoConfig(BaseModel):
-    """Root configuration file for Indico source definitions."""
+    """Backward-compatible config view for legacy call sites/tests."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -33,20 +21,29 @@ class IndicoConfig(BaseModel):
 
 
 def load_indico_config(path: Path) -> IndicoConfig:
-    """Load config from disk, returning an empty config when file is missing."""
     if not path.exists():
         return IndicoConfig()
-    raw_data = read_yaml(path)
-    return IndicoConfig.model_validate(raw_data)
+    project = load_project_file(path)
+    return IndicoConfig(sources=project.indico_category_sources)
 
 
 def save_indico_config(path: Path, config: IndicoConfig) -> None:
-    """Persist config to disk in a deterministic order."""
-    serialized = config.model_dump(mode="json")
-    serialized["sources"] = sorted(serialized["sources"], key=lambda item: item["name"])
-    for source in serialized["sources"]:
-        if not source.get("title_matches"):
-            source.pop("title_matches", None)
-        if not source.get("title_exclude_patterns"):
-            source.pop("title_exclude_patterns", None)
-    write_yaml(path, serialized)
+    project = load_project_file(path) if path.exists() else None
+    if project is None:
+        today = date.today().isoformat()
+        project = ProjectFile.model_validate(
+            {
+                "schema_version": "1.0",
+                "metadata": {"name": path.stem},
+                "date_window": {"start_date": today},
+                "event_type_styles": {},
+                "events": [],
+            }
+        )
+    save_project_file(
+        path,
+        project.model_copy(update={"indico_category_sources": config.sources}),
+    )
+
+
+__all__ = ["IndicoConfig", "IndicoSource", "load_indico_config", "save_indico_config"]

--- a/committee_builder/io/normalize.py
+++ b/committee_builder/io/normalize.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from committee_builder.schema.models import CommitteeHistory
+from committee_builder.schema.models import ProjectFile
 
 
-def normalize_history(history: CommitteeHistory) -> CommitteeHistory:
+def normalize_history(history: ProjectFile) -> ProjectFile:
     """Return a copy with a stable event sort (date, then id)."""
     sorted_events = sorted(history.events, key=lambda e: (e.date, e.id))
     return history.model_copy(update={"events": sorted_events})

--- a/committee_builder/io/yaml_io.py
+++ b/committee_builder/io/yaml_io.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import yaml
 
+from committee_builder.schema.models import ProjectFile
+
 
 def read_yaml(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as f:
@@ -31,6 +33,15 @@ def _strip_none_values(value: Any) -> Any:
 def write_yaml(path: Path, data: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(
-            _strip_none_values(data), f, sort_keys=False, allow_unicode=True
-        )
+        yaml.safe_dump(_strip_none_values(data), f, sort_keys=False, allow_unicode=True)
+
+
+def load_project_file(path: Path) -> ProjectFile:
+    """Load a project YAML file from disk."""
+    raw = read_yaml(path)
+    return ProjectFile.model_validate(raw)
+
+
+def save_project_file(path: Path, project: ProjectFile) -> None:
+    """Persist a project YAML file to disk."""
+    write_yaml(path, project.model_dump(mode="json"))

--- a/committee_builder/pipeline/build_pipeline.py
+++ b/committee_builder/pipeline/build_pipeline.py
@@ -15,7 +15,14 @@ from committee_builder.render.markdown import render_markdown
 
 def _render_payload(history) -> dict:
     payload = history.model_dump(mode="json")
-    committee = payload["committee"]
+    metadata = payload["metadata"]
+    date_window = payload["date_window"]
+    committee = {
+        **metadata,
+        "start_date": date_window.get("start_date"),
+        "end_date": date_window.get("end_date"),
+    }
+    payload["committee"] = committee
     committee["description_html"] = render_markdown(committee.get("description_md"))
     committee["notes_html"] = render_markdown(committee.get("notes_md"))
 
@@ -60,7 +67,7 @@ def build_html(
 
     data_json = json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
     html = template.render(
-        page_title=payload["committee"]["name"],
+        page_title=payload["metadata"]["name"],
         css=css,
         app_js=js,
         data_json=data_json,

--- a/committee_builder/pipeline/validate_pipeline.py
+++ b/committee_builder/pipeline/validate_pipeline.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from committee_builder.io.yaml_io import read_yaml
-from committee_builder.schema.models import CommitteeHistory
+from committee_builder.schema.models import ProjectFile
 from committee_builder.schema.validators import (
     SemanticValidationError,
     validate_semantics,
@@ -17,7 +17,7 @@ from committee_builder.schema.validators import (
 
 @dataclass
 class PipelineValidationResult:
-    history: CommitteeHistory
+    history: ProjectFile
     warnings: list[str]
 
 
@@ -26,7 +26,7 @@ def validate_yaml(input_yaml: Path) -> PipelineValidationResult:
     raw = read_yaml(input_yaml)
 
     try:
-        history = CommitteeHistory.model_validate(raw)
+        history = ProjectFile.model_validate(raw)
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc
 

--- a/committee_builder/schema/models.py
+++ b/committee_builder/schema/models.py
@@ -1,11 +1,11 @@
-"""Schema models for committee history source files."""
+"""Schema models for committee project source files."""
 
 from __future__ import annotations
 
 from datetime import date
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class EventType(str, Enum):
@@ -41,15 +41,27 @@ class EventTypeStyle(BaseModel):
     color: str = Field(min_length=1)
 
 
-class CommitteeMetadata(BaseModel):
+class ProjectMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(min_length=1)
     subtitle: str | None = None
     description_md: str | None = None
+    notes_md: str | None = None
+
+
+class DateWindow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     start_date: date
     end_date: date | None = None
-    notes_md: str | None = None
+
+
+class CommitteeMetadata(ProjectMetadata):
+    """Backward-compatible metadata view for older call sites."""
+
+    start_date: date
+    end_date: date | None = None
 
 
 class CommitteeEvent(BaseModel):
@@ -75,6 +87,70 @@ class CommitteeHistory(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: str = Field(default="1.0")
-    committee: CommitteeMetadata
+    metadata: ProjectMetadata
+    date_window: DateWindow
     event_type_styles: dict[EventType, EventTypeStyle]
     events: list[CommitteeEvent] = Field(default_factory=list)
+    indico_meeting_source: IndicoSource | None = None
+    indico_category_sources: list[IndicoSource] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_fields(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        data = dict(value)
+
+        committee = data.pop("committee", None)
+        if isinstance(committee, dict):
+            if "metadata" not in data:
+                data["metadata"] = {
+                    "name": committee.get("name"),
+                    "subtitle": committee.get("subtitle"),
+                    "description_md": committee.get("description_md"),
+                    "notes_md": committee.get("notes_md"),
+                }
+            if "date_window" not in data:
+                data["date_window"] = {
+                    "start_date": committee.get("start_date"),
+                    "end_date": committee.get("end_date"),
+                }
+
+        if "sources" in data and "indico_category_sources" not in data:
+            data["indico_category_sources"] = data.pop("sources")
+        if "metadata" not in data:
+            data["metadata"] = {"name": "Committee Project"}
+        if "date_window" not in data:
+            data["date_window"] = {"start_date": date.today().isoformat()}
+        if "event_type_styles" not in data:
+            data["event_type_styles"] = {}
+        if "events" not in data:
+            data["events"] = []
+        return data
+
+    @property
+    def committee(self) -> CommitteeMetadata:
+        return CommitteeMetadata(
+            name=self.metadata.name,
+            subtitle=self.metadata.subtitle,
+            description_md=self.metadata.description_md,
+            notes_md=self.metadata.notes_md,
+            start_date=self.date_window.start_date,
+            end_date=self.date_window.end_date,
+        )
+
+
+ProjectFile = CommitteeHistory
+
+
+class IndicoSource(BaseModel):
+    """Configured Indico category source."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(min_length=1)
+    category_id: int
+    base_url: str = Field(min_length=1)
+    color: str = Field(min_length=1)
+    title_matches: list[str] = Field(default_factory=list)
+    title_exclude_patterns: list[str] = Field(default_factory=list)

--- a/committee_builder/schema/validators.py
+++ b/committee_builder/schema/validators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from committee_builder.schema.models import CommitteeHistory
+from committee_builder.schema.models import ProjectFile
 
 
 @dataclass
@@ -20,34 +20,34 @@ class SemanticValidationError(ValueError):
         super().__init__("; ".join(errors))
 
 
-def validate_semantics(history: CommitteeHistory) -> ValidationResult:
+def validate_semantics(project: ProjectFile) -> ValidationResult:
     """Validate semantic rules that go beyond type/schema checks."""
     errors: list[str] = []
     warnings: list[str] = []
 
     ids: set[str] = set()
-    for event in history.events:
+    for event in project.events:
         if event.id in ids:
             errors.append(f"Duplicate event id: {event.id}")
         ids.add(event.id)
 
-        if event.date < history.committee.start_date:
+        if event.date < project.date_window.start_date:
             warnings.append(
-                f"Event {event.id} date {event.date.isoformat()} is before committee start_date "
-                f"{history.committee.start_date.isoformat()}"
+                f"Event {event.id} date {event.date.isoformat()} is before date_window.start_date "
+                f"{project.date_window.start_date.isoformat()}"
             )
 
-        if history.committee.end_date and event.date > history.committee.end_date:
+        if project.date_window.end_date and event.date > project.date_window.end_date:
             warnings.append(
-                f"Event {event.id} date {event.date.isoformat()} is after committee end_date "
-                f"{history.committee.end_date.isoformat()}"
+                f"Event {event.id} date {event.date.isoformat()} is after date_window.end_date "
+                f"{project.date_window.end_date.isoformat()}"
             )
 
     if (
-        history.committee.end_date
-        and history.committee.end_date < history.committee.start_date
+        project.date_window.end_date
+        and project.date_window.end_date < project.date_window.start_date
     ):
-        errors.append("committee.end_date cannot be before committee.start_date")
+        errors.append("date_window.end_date cannot be before date_window.start_date")
 
     if errors:
         raise SemanticValidationError(errors)

--- a/tests/test_sources_cli.py
+++ b/tests/test_sources_cli.py
@@ -62,17 +62,17 @@ def test_indico_add_list_remove() -> None:
         )
         assert add_result.exit_code == 0
 
-        config_data = yaml.safe_load(config.with_suffix(".yaml").read_text(encoding="utf-8"))
-        assert config_data["sources"][0]["color"].startswith("#")
+        config_data = yaml.safe_load(
+            config.with_suffix(".yaml").read_text(encoding="utf-8")
+        )
+        assert config_data["indico_category_sources"][0]["color"].startswith("#")
 
         list_result = runner.invoke(app, ["indico", "list", str(config)])
         assert list_result.exit_code == 0
         assert "cern: category=42" in list_result.stdout
         assert "color=" in list_result.stdout
 
-        remove_result = runner.invoke(
-            app, ["indico", "remove", str(config), "cern"]
-        )
+        remove_result = runner.invoke(app, ["indico", "remove", str(config), "cern"])
         assert remove_result.exit_code == 0
 
         empty_result = runner.invoke(app, ["indico", "list", str(config)])
@@ -238,9 +238,7 @@ def test_indico_generate_skips_meetings_matching_title_excludes(
 
         rendered = output_path.read_text(encoding="utf-8")
         parsed = yaml.safe_load(rendered)
-        assert [event["title"] for event in parsed["events"]] == [
-            "Weekly Coordination"
-        ]
+        assert [event["title"] for event in parsed["events"]] == ["Weekly Coordination"]
         assert "High School Meeting" not in rendered
         assert "Weekly Coordination" in rendered
 
@@ -250,14 +248,13 @@ def test_indico_api_key_creates_and_updates_local_dotenv() -> None:
         base_url = "https://indico.example.com/indico/"
         env_name = api_key_env_name(base_url)
 
-        first_result = runner.invoke(
-            app, ["indico", "api-key", base_url, "first-key"]
-        )
+        first_result = runner.invoke(app, ["indico", "api-key", base_url, "first-key"])
         assert first_result.exit_code == 0
         assert Path(".env").read_text(encoding="utf-8") == f"{env_name}=first-key\n"
 
         second_result = runner.invoke(
-            app, ["indico", "api-key", "https://indico.example.com/indico", "updated-key"]
+            app,
+            ["indico", "api-key", "https://indico.example.com/indico", "updated-key"],
         )
         assert second_result.exit_code == 0
         assert Path(".env").read_text(encoding="utf-8") == f"{env_name}=updated-key\n"
@@ -324,7 +321,10 @@ def test_indico_add_uses_category_title_when_not_provided(
             ["indico", "list", "my-project"],
         )
         assert list_result.exit_code == 0
-        assert "ATLAS: category=77, base_url=https://indico.example.com/indico, color=" in list_result.stdout
+        assert (
+            "ATLAS: category=77, base_url=https://indico.example.com/indico, color="
+            in list_result.stdout
+        )
 
 
 def test_indico_add_logs_auth_error_for_protected_category(
@@ -369,7 +369,9 @@ def test_indico_add_normalizes_named_color() -> None:
         assert result.exit_code == 0
 
         config_data = yaml.safe_load(Path("colors.yaml").read_text(encoding="utf-8"))
-        assert config_data["sources"][0]["color"] == _normalize_source_color("red")
+        assert config_data["indico_category_sources"][0][
+            "color"
+        ] == _normalize_source_color("red")
 
 
 def test_indico_add_normalizes_hex_color() -> None:
@@ -390,7 +392,9 @@ def test_indico_add_normalizes_hex_color() -> None:
         assert result.exit_code == 0
 
         config_data = yaml.safe_load(Path("colors.yaml").read_text(encoding="utf-8"))
-        assert config_data["sources"][0]["color"] == _normalize_source_color("#88ccff")
+        assert config_data["indico_category_sources"][0][
+            "color"
+        ] == _normalize_source_color("#88ccff")
 
 
 def test_indico_add_assigns_unique_generated_colors() -> None:
@@ -421,7 +425,7 @@ def test_indico_add_assigns_unique_generated_colors() -> None:
         assert second.exit_code == 0
 
         config_data = yaml.safe_load(Path("colors.yaml").read_text(encoding="utf-8"))
-        colors = [source["color"] for source in config_data["sources"]]
+        colors = [source["color"] for source in config_data["indico_category_sources"]]
         assert len(colors) == len(set(colors))
 
 
@@ -704,7 +708,10 @@ def test_indico_generate_converts_html_descriptions_to_markdown(
         assert "- *Risks*" in rendered
         assert "minutes_md:" in rendered
         assert "Minutes approved." in rendered
-        assert "![plot](https://indico.example.com/event/1001/attachments/7/8/plot.png)" in rendered
+        assert (
+            "![plot](https://indico.example.com/event/1001/attachments/7/8/plot.png)"
+            in rendered
+        )
         assert "- Action one" in rendered
         assert "Talk note with *formatting*." in rendered
         assert "| Talk | Speakers | Documents |" in rendered
@@ -1502,7 +1509,9 @@ def test_short_contribution_title_prefers_indico_contribution_title() -> None:
         ],
     )
 
-    assert _short_contribution_title(contribution) == "Lossy compression for FTAG branches"
+    assert (
+        _short_contribution_title(contribution) == "Lossy compression for FTAG branches"
+    )
 
 
 def test_short_contribution_title_falls_back_to_cleaned_filename() -> None:
@@ -1517,18 +1526,26 @@ def test_short_contribution_title_falls_back_to_cleaned_filename() -> None:
         ],
     )
 
-    assert _short_contribution_title(contribution) == "Lossy Compression Studies In FTAG"
+    assert (
+        _short_contribution_title(contribution) == "Lossy Compression Studies In FTAG"
+    )
 
 
 def test_short_contribution_title_uses_placeholder_without_title_or_documents() -> None:
-    contribution = IndicoContribution(title="", speaker_names=["Romain Bouquet"], documents=[])
+    contribution = IndicoContribution(
+        title="", speaker_names=["Romain Bouquet"], documents=[]
+    )
 
     assert _short_contribution_title(contribution) == "Untitled talk"
 
 
 def test_build_document_link_labels_uses_talk_for_single_upload() -> None:
     labels = _build_document_link_labels(
-        [IndicoDocument(label="Very long filename.pdf", url="https://example.org/slides.pdf")]
+        [
+            IndicoDocument(
+                label="Very long filename.pdf", url="https://example.org/slides.pdf"
+            )
+        ]
     )
 
     assert labels == ["Talk"]
@@ -1559,8 +1576,8 @@ def test_compact_unique_labels_reverts_colliding_word_boundary_rollbacks() -> No
         ]
     )
 
-    assert labels == ["Alpha beta one file.", "Alpha beta one note.", "Gamma delta report"]
-
-
-
-
+    assert labels == [
+        "Alpha beta one file.",
+        "Alpha beta one note.",
+        "Gamma delta report",
+    ]


### PR DESCRIPTION
### Motivation
- Provide a single root model for project YAMLs that contains global metadata, a default date window, events, and Indico sources so all project data is stored/validated as one document.
- Simplify validation, IO, and Indico CLI flows by routing load/save through a unified YAML representation rather than a separate Indico config file.

### Description
- Added a unified root model `ProjectFile` (aliasing the updated `CommitteeHistory`) with `metadata`, `date_window`, `events`, optional `indico_meeting_source`, and `indico_category_sources`, and a migration validator to accept legacy `committee`/`sources` keys in `committee_builder/schema/models.py`.
- Refactored semantic validation and the pipeline entrypoint to validate the `ProjectFile` root and to use the `date_window` semantics in `committee_builder/schema/validators.py` and `committee_builder/pipeline/validate_pipeline.py`.
- Introduced `load_project_file` and `save_project_file` in `committee_builder/io/yaml_io.py` and switched Indico add/list/remove/generate commands to persist sources via the project YAML in `committee_builder/commands/sources.py` while keeping `committee_builder/indico/config.py` as a backward-compatible shim that now maps to the project file APIs.
- Updated the build payload and starter document to expose a `committee` view for templates while storing `metadata` + `date_window` in the root, and adjusted the `init` document shape and affected code paths accordingly (`committee_builder/pipeline/build_pipeline.py`, `committee_builder/commands/init.py`).

### Testing
- Ran `black` on modified files (`black committee_builder tests`) which reformatted files without error.
- Attempted `flake8` but it is not installed in the environment (`flake8: command not found`).
- Ran `pytest` (`pytest`) and all tests passed: `68 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c221204e408320a41dde2a8222e020)