### PR TITLE
Revamp committee CLI UX around init/add/build workflows

### DIFF
--- a/committee_builder/cli.py
+++ b/committee_builder/cli.py
@@ -6,9 +6,12 @@ import logging
 
 import typer
 
+from committee_builder.commands.add import (
+    add_event_command,
+    add_indico_category_command,
+    add_minutes_command,
+)
 from committee_builder.commands.build import build_command
-from committee_builder.commands.import_csv import import_csv_command
-from committee_builder.commands.import_md import import_md_command
 from committee_builder.commands.init import init_command
 from committee_builder.commands.sources import (
     add_source_command,
@@ -46,9 +49,9 @@ def main_callback(
     """Committee history tooling.
 
     Examples:
-      committee validate data/committee.history.yaml
-      committee build data/committee.history.yaml
-      committee -vv build data/committee.history.yaml --overwrite
+      committee init project.yaml --title "Steering Committee" --from 2024-01-01 --to 2025-12-31
+      committee add event project.yaml --title "Kickoff" --date 2024-01-12
+      committee build project.yaml --from 2024-01-01 --to 2024-12-31
     """
     configure_logging(verbose)
     logger.debug("CLI initialized with verbosity=%s", verbose)
@@ -61,16 +64,21 @@ app.command(
     "validate", help="Validate a YAML source file against schema and semantic checks."
 )(validate_command)
 app.command("init", help="Create a starter YAML source file.")(init_command)
-app.command("import-csv", help="Placeholder for future CSV import workflow.")(
-    import_csv_command
-)
-app.command("import-md", help="Placeholder for future markdown import workflow.")(
-    import_md_command
-)
 
-indico_app = typer.Typer(
-    help="Manage Indico categories and generate imported meetings."
+add_app = typer.Typer(help="Add events, Indico categories, and minutes content.")
+add_app.command("event", help="Add a local event entry to project YAML.")(
+    add_event_command
 )
+add_app.command("indico", help="Add an Indico category source to project config.")(
+    add_indico_category_command
+)
+add_app.command(
+    "minutes",
+    help="Import minutes text file content into markdown fields in YAML.",
+)(add_minutes_command)
+app.add_typer(add_app, name="add")
+
+indico_app = typer.Typer(help="Manage Indico categories and local API credentials.")
 indico_app.command("add", help="Add an Indico category to the project config.")(
     add_source_command
 )
@@ -90,9 +98,11 @@ indico_app.command(
 indico_app.command("remove", help="Remove an Indico category from the config.")(
     remove_source_command
 )
-indico_app.command("generate", help="Generate meetings YAML from configured categories.")(
-    generate_sources_command
-)
+indico_app.command(
+    "generate",
+    hidden=True,
+    help="Deprecated: use `committee build` with date overrides.",
+)(generate_sources_command)
 
 app.add_typer(indico_app, name="indico")
 

--- a/committee_builder/commands/add.py
+++ b/committee_builder/commands/add.py
@@ -1,0 +1,111 @@
+"""Top-level add command implementations."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from committee_builder.commands.sources import add_source_command
+from committee_builder.io.yaml_io import read_yaml, write_yaml
+
+logger = logging.getLogger(__name__)
+
+
+def add_event_command(
+    project_yaml: Path = typer.Argument(
+        ..., exists=True, dir_okay=False, readable=True, help="Project YAML path."
+    ),
+    title: str = typer.Option(..., "--title", help="Event title."),
+    date: str = typer.Option(..., "--date", help="Event date in YYYY-MM-DD."),
+    event_id: str | None = typer.Option(None, "--id", help="Optional event id."),
+    event_type: str = typer.Option("meeting", "--type", help="Event type."),
+    summary_md: str = typer.Option(
+        "Added from committee add event.", "--summary-md", help="Markdown summary."
+    ),
+) -> None:
+    """Add a local event entry directly to a project YAML file."""
+    payload = read_yaml(project_yaml)
+    events = payload.setdefault("events", [])
+    if not isinstance(events, list):
+        raise typer.BadParameter("`events` must be a list in the project YAML.")
+
+    new_event_id = event_id or f"evt-{len(events) + 1:03d}"
+    event_doc: dict[str, Any] = {
+        "id": new_event_id,
+        "type": event_type,
+        "title": title,
+        "date": date,
+        "important": False,
+        "summary_md": summary_md,
+        "participants": [],
+        "tags": [],
+        "documents": [],
+        "contributions": [],
+    }
+    events.append(event_doc)
+    write_yaml(project_yaml, payload)
+    logger.info("Added event '%s' to %s", new_event_id, project_yaml)
+
+
+def add_indico_category_command(
+    project_config: Path = typer.Argument(
+        ..., help="Project config path or project name (adds .yaml if omitted)."
+    ),
+    category_url: str = typer.Argument(
+        ..., help="Full Indico category URL, e.g. https://host/category/1234/."
+    ),
+    title: str | None = typer.Option(
+        None,
+        "--title",
+        help="Optional source title. Defaults to fetched category title.",
+    ),
+) -> None:
+    """Add an Indico category source to project configuration."""
+    add_source_command(config=project_config, category_url=category_url, title=title)
+
+
+def add_minutes_command(
+    project_yaml: Path = typer.Argument(
+        ..., exists=True, dir_okay=False, readable=True, help="Project YAML path."
+    ),
+    event_id: str = typer.Argument(..., help="Event id to update."),
+    minutes_file: Path = typer.Argument(
+        ...,
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Minutes text/markdown path.",
+    ),
+    field: str = typer.Option(
+        "minutes_md",
+        "--field",
+        help="Event markdown field to fill (minutes_md or summary_md).",
+    ),
+) -> None:
+    """Import minutes text file content into an event markdown field."""
+    if field not in {"minutes_md", "summary_md"}:
+        raise typer.BadParameter("--field must be minutes_md or summary_md.")
+
+    payload = read_yaml(project_yaml)
+    events = payload.get("events", [])
+    if not isinstance(events, list):
+        raise typer.BadParameter("`events` must be a list in the project YAML.")
+
+    minutes_text = minutes_file.read_text(encoding="utf-8").strip()
+    for event in events:
+        if isinstance(event, dict) and event.get("id") == event_id:
+            event[field] = minutes_text
+            write_yaml(project_yaml, payload)
+            logger.info(
+                "Imported %s into event '%s' (%s) in %s",
+                minutes_file,
+                event_id,
+                field,
+                project_yaml,
+            )
+            return
+
+    raise typer.BadParameter(f"Event not found: {event_id}")

--- a/committee_builder/commands/build.py
+++ b/committee_builder/commands/build.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import date, timedelta
 from pathlib import Path
 
 import typer
@@ -13,12 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 def build_command(
-    input_yaml: Path = typer.Argument(
+    project_yaml: Path = typer.Argument(
         ...,
         exists=True,
         dir_okay=False,
         readable=True,
-        help="Path to the input YAML file.",
+        help="Path to the project YAML file.",
     ),
     output: Path | None = typer.Option(
         None,
@@ -31,17 +32,85 @@ def build_command(
         "--overwrite",
         help="Allow overwriting an existing output file.",
     ),
+    from_date: str | None = typer.Option(
+        None, "--from", help="Override start date (YYYY-MM-DD)."
+    ),
+    to_date: str | None = typer.Option(
+        None, "--to", help="Override end date (YYYY-MM-DD)."
+    ),
+    past_weeks: int | None = typer.Option(
+        None, "--past-weeks", help="Bracket range start relative to today."
+    ),
+    future_weeks: int | None = typer.Option(
+        None, "--future-weeks", help="Bracket range end relative to today."
+    ),
 ) -> None:
     """Build a standalone committee history HTML page.
 
     The output contains inlined CSS, JS, and committee data.
     """
+    parsed_from = _parse_iso_date(from_date, option_name="--from")
+    parsed_to = _parse_iso_date(to_date, option_name="--to")
+    range_start, range_end = _resolve_range(
+        from_date=parsed_from,
+        to_date=parsed_to,
+        past_weeks=past_weeks,
+        future_weeks=future_weeks,
+    )
     try:
         output_path = build_html(
-            input_yaml=input_yaml, output_path=output, overwrite=overwrite
+            input_yaml=project_yaml,
+            output_path=output,
+            overwrite=overwrite,
+            from_date=range_start,
+            to_date=range_end,
         )
     except Exception as exc:  # noqa: BLE001
         logger.error("Build failed: %s", exc)
         raise typer.Exit(code=1) from exc
 
     logger.info("Build succeeded: %s", output_path)
+
+
+def _parse_iso_date(value: str | None, *, option_name: str) -> date | None:
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise typer.BadParameter(
+            f"{option_name} must be in YYYY-MM-DD format."
+        ) from exc
+
+
+def _resolve_range(
+    from_date: date | None,
+    to_date: date | None,
+    past_weeks: int | None,
+    future_weeks: int | None,
+) -> tuple[date | None, date | None]:
+    if (past_weeks is not None or future_weeks is not None) and (
+        from_date is not None or to_date is not None
+    ):
+        raise typer.BadParameter(
+            "Use either --from/--to or --past-weeks/--future-weeks."
+        )
+
+    if from_date is not None or to_date is not None:
+        if from_date is not None and to_date is not None and from_date > to_date:
+            raise typer.BadParameter("--from must be before or equal to --to.")
+        return from_date, to_date
+
+    if past_weeks is None and future_weeks is None:
+        return None, None
+
+    today = date.today()
+    range_start = (
+        today - timedelta(weeks=past_weeks) if past_weeks is not None else None
+    )
+    range_end = (
+        today + timedelta(weeks=future_weeks) if future_weeks is not None else None
+    )
+    if range_start is not None and range_end is not None and range_start > range_end:
+        raise typer.BadParameter("Computed date window is invalid.")
+    return range_start, range_end

--- a/committee_builder/commands/init.py
+++ b/committee_builder/commands/init.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import typer
 
@@ -48,6 +49,23 @@ STARTER_DOC = {
 }
 
 
+def _build_starter_doc(
+    title: str, from_date: str, to_date: str | None
+) -> dict[str, Any]:
+    starter_doc: dict[str, Any] = {
+        **STARTER_DOC,
+        "metadata": {
+            **STARTER_DOC["metadata"],
+            "name": title,
+        },
+        "date_window": {
+            "start_date": from_date,
+            "end_date": to_date or from_date,
+        },
+    }
+    return starter_doc
+
+
 def init_command(
     path: Path = typer.Argument(
         ..., help="Path where the starter YAML should be created."
@@ -55,11 +73,28 @@ def init_command(
     force: bool = typer.Option(
         False, "--force", help="Overwrite existing file if present."
     ),
+    title: str = typer.Option(
+        "Committee Project",
+        "--title",
+        help="Project title to store in metadata.name.",
+    ),
+    from_date: str = typer.Option(
+        "2023-01-01",
+        "--from",
+        help="Default date window start (YYYY-MM-DD).",
+    ),
+    to_date: str | None = typer.Option(
+        "2024-12-31",
+        "--to",
+        help="Default date window end (YYYY-MM-DD).",
+    ),
 ) -> None:
     """Create a starter YAML source file."""
     if path.exists() and not force:
         logger.error("File already exists: %s (use --force to overwrite)", path)
         raise typer.Exit(code=1)
 
-    write_yaml(path, STARTER_DOC)
+    write_yaml(
+        path, _build_starter_doc(title=title, from_date=from_date, to_date=to_date)
+    )
     logger.info("Starter file created: %s", path)

--- a/committee_builder/pipeline/build_pipeline.py
+++ b/committee_builder/pipeline/build_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -11,6 +12,7 @@ from committee_builder.io.normalize import normalize_history
 from committee_builder.io.paths import default_output_html
 from committee_builder.pipeline.validate_pipeline import validate_yaml
 from committee_builder.render.markdown import render_markdown
+from committee_builder.schema.models import DateWindow, ProjectFile
 
 
 def _render_payload(history) -> dict:
@@ -50,12 +52,40 @@ def _load_template_assets() -> tuple[str, str, Environment]:
     return css, js, env
 
 
+def _apply_date_override(
+    history: ProjectFile, from_date: date | None, to_date: date | None
+) -> ProjectFile:
+    if from_date is None and to_date is None:
+        return history
+
+    window_start = from_date or history.date_window.start_date
+    window_end = to_date if to_date is not None else history.date_window.end_date
+    filtered_events = [
+        event
+        for event in history.events
+        if event.date >= window_start
+        and (window_end is None or event.date <= window_end)
+    ]
+
+    return history.model_copy(
+        update={
+            "date_window": DateWindow(start_date=window_start, end_date=window_end),
+            "events": filtered_events,
+        }
+    )
+
+
 def build_html(
-    input_yaml: Path, output_path: Path | None, overwrite: bool = False
+    input_yaml: Path,
+    output_path: Path | None,
+    overwrite: bool = False,
+    from_date: date | None = None,
+    to_date: date | None = None,
 ) -> Path:
     """Build a standalone HTML file from the YAML input."""
     result = validate_yaml(input_yaml)
-    history = normalize_history(result.history)
+    history = _apply_date_override(result.history, from_date=from_date, to_date=to_date)
+    history = normalize_history(history)
     payload = _render_payload(history)
 
     target = output_path if output_path is not None else default_output_html(input_yaml)


### PR DESCRIPTION
### Motivation

- Provide a simpler, more discoverable CLI UX by introducing a top-level `add` group for common local workflows (events, Indico categories, minutes imports). 
- Make `init` able to seed project metadata and a default date window so starter files match expected project settings. 
- Allow `build` to render a project restricted to a custom date window (absolute or week-bracketing) and deprecate the older visible `indico generate` flow in favor of `build` with overrides.

### Description

- Added a new command module and top-level group `committee add` with subcommands `event`, `indico`, and `minutes` implemented in `committee_builder/commands/add.py`. 
- Extended `committee init` to accept `--title`, `--from`, and `--to` and generate a starter YAML reflecting those values (`committee_builder/commands/init.py`). 
- Reworked `committee build` to accept a project YAML (renamed positional), date override flags `--from/--to` and relative `--past-weeks/--future-weeks`, with validation and parsing in `committee_builder/commands/build.py`. 
- Updated the build pipeline to apply date-window overrides and filter events before rendering (`committee_builder/pipeline/build_pipeline.py`). 
- CLI registration and help text were updated in `committee_builder/cli.py` to add the `add` group, adjust examples, and hide the old `indico generate` command as a deprecated compatibility alias.

### Testing

- Ran the test suite with `python -m pytest` which completed successfully with `68 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2297fe9c48320aabc9eac56b3232c)