### PR TITLE
Unify date-range resolution for build and indico generate

### DIFF
--- a/committee_builder/commands/build.py
+++ b/committee_builder/commands/build.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
-from datetime import date, timedelta
 from pathlib import Path
 
 import typer
 
 from committee_builder.pipeline.build_pipeline import build_html
+from committee_builder.pipeline.date_range import (
+    parse_cli_range_options,
+    resolve_build_range,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,13 +52,15 @@ def build_command(
 
     The output contains inlined CSS, JS, and committee data.
     """
-    parsed_from = _parse_iso_date(from_date, option_name="--from")
-    parsed_to = _parse_iso_date(to_date, option_name="--to")
-    range_start, range_end = _resolve_range(
-        from_date=parsed_from,
-        to_date=parsed_to,
+    range_options = parse_cli_range_options(
+        from_date=from_date,
+        to_date=to_date,
         past_weeks=past_weeks,
         future_weeks=future_weeks,
+    )
+    range_start, range_end = resolve_build_range(
+        project_yaml=project_yaml,
+        options=range_options,
     )
     try:
         output_path = build_html(
@@ -70,47 +75,3 @@ def build_command(
         raise typer.Exit(code=1) from exc
 
     logger.info("Build succeeded: %s", output_path)
-
-
-def _parse_iso_date(value: str | None, *, option_name: str) -> date | None:
-    if value is None:
-        return None
-    try:
-        return date.fromisoformat(value)
-    except ValueError as exc:
-        raise typer.BadParameter(
-            f"{option_name} must be in YYYY-MM-DD format."
-        ) from exc
-
-
-def _resolve_range(
-    from_date: date | None,
-    to_date: date | None,
-    past_weeks: int | None,
-    future_weeks: int | None,
-) -> tuple[date | None, date | None]:
-    if (past_weeks is not None or future_weeks is not None) and (
-        from_date is not None or to_date is not None
-    ):
-        raise typer.BadParameter(
-            "Use either --from/--to or --past-weeks/--future-weeks."
-        )
-
-    if from_date is not None or to_date is not None:
-        if from_date is not None and to_date is not None and from_date > to_date:
-            raise typer.BadParameter("--from must be before or equal to --to.")
-        return from_date, to_date
-
-    if past_weeks is None and future_weeks is None:
-        return None, None
-
-    today = date.today()
-    range_start = (
-        today - timedelta(weeks=past_weeks) if past_weeks is not None else None
-    )
-    range_end = (
-        today + timedelta(weeks=future_weeks) if future_weeks is not None else None
-    )
-    if range_start is not None and range_end is not None and range_start > range_end:
-        raise typer.BadParameter("Computed date window is invalid.")
-    return range_start, range_end

--- a/committee_builder/commands/sources.py
+++ b/committee_builder/commands/sources.py
@@ -26,6 +26,10 @@ from committee_builder.io.yaml_io import (
     save_project_file,
     write_yaml,
 )
+from committee_builder.pipeline.date_range import (
+    parse_cli_range_options,
+    resolve_cli_range,
+)
 from committee_builder.pipeline.validate_pipeline import (
     PipelineValidationResult,
     validate_yaml,
@@ -428,11 +432,20 @@ def generate_sources_command(
 ) -> None:
     """Generate a new committee YAML with imported Indico meeting events."""
     config_path = _normalize_config_path(config)
-    parsed_from = _parse_iso_date(from_date, option_name="--from")
-    parsed_to = _parse_iso_date(to_date, option_name="--to")
-    range_start, range_end = _resolve_range(
-        parsed_from, parsed_to, past_weeks, future_weeks
+    range_options = parse_cli_range_options(
+        from_date=from_date,
+        to_date=to_date,
+        past_weeks=past_weeks,
+        future_weeks=future_weeks,
     )
+    resolved_range = resolve_cli_range(
+        range_options,
+        require_absolute_pair=True,
+        default_relative_weeks=(0, 0),
+    )
+    if resolved_range is None:
+        raise typer.BadParameter("Unable to resolve source generation date range.")
+    range_start, range_end = resolved_range
     project = _load_or_init_project(config_path)
     selected = _select_sources(project, source)
     generate_paths = _resolve_generate_paths(
@@ -791,48 +804,6 @@ def _blend_rgb(
 ) -> tuple[int, int, int]:
     clamped_weight = max(0.0, min(1.0, weight_to_white))
     return tuple(round(channel + (255 - channel) * clamped_weight) for channel in rgb)
-
-
-def _resolve_range(
-    from_date: date | None,
-    to_date: date | None,
-    past_weeks: int | None,
-    future_weeks: int | None,
-) -> tuple[date, date]:
-    has_absolute = from_date is not None or to_date is not None
-    has_relative = past_weeks is not None or future_weeks is not None
-
-    if has_absolute and has_relative:
-        raise typer.BadParameter(
-            "Use either --from/--to or --past-weeks/--future-weeks, not both."
-        )
-
-    if has_absolute:
-        if from_date is None or to_date is None:
-            raise typer.BadParameter(
-                "Both --from and --to are required for absolute ranges."
-            )
-        if to_date < from_date:
-            raise typer.BadParameter("--to cannot be before --from.")
-        return from_date, to_date
-
-    current_day = date.today()
-    effective_past_weeks = past_weeks or 0
-    effective_future_weeks = future_weeks or 0
-    start = current_day - timedelta(weeks=effective_past_weeks)
-    end = current_day + timedelta(weeks=effective_future_weeks)
-    if end < start:
-        raise typer.BadParameter("Computed relative range is invalid.")
-    return start, end
-
-
-def _parse_iso_date(value: str | None, option_name: str) -> date | None:
-    if value is None:
-        return None
-    try:
-        return date.fromisoformat(value)
-    except ValueError as exc:
-        raise typer.BadParameter(f"Invalid date for {option_name}: {value}") from exc
 
 
 def _select_sources(project: ProjectFile, names: list[str]) -> list[IndicoSource]:

--- a/committee_builder/pipeline/date_range.py
+++ b/committee_builder/pipeline/date_range.py
@@ -1,0 +1,125 @@
+"""Shared date range parsing and resolution helpers."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+import typer
+
+from committee_builder.pipeline.validate_pipeline import validate_yaml
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ParsedRangeOptions:
+    """Parsed date range options from CLI arguments."""
+
+    from_date: date | None
+    to_date: date | None
+    past_weeks: int | None
+    future_weeks: int | None
+
+
+def parse_iso_date_option(value: str | None, *, option_name: str) -> date | None:
+    """Parse a single ISO date option."""
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise typer.BadParameter(
+            f"{option_name} must be in YYYY-MM-DD format."
+        ) from exc
+
+
+def parse_cli_range_options(
+    *,
+    from_date: str | None,
+    to_date: str | None,
+    past_weeks: int | None,
+    future_weeks: int | None,
+) -> ParsedRangeOptions:
+    """Parse CLI date range options into a typed container."""
+    return ParsedRangeOptions(
+        from_date=parse_iso_date_option(from_date, option_name="--from"),
+        to_date=parse_iso_date_option(to_date, option_name="--to"),
+        past_weeks=past_weeks,
+        future_weeks=future_weeks,
+    )
+
+
+def resolve_cli_range(
+    options: ParsedRangeOptions,
+    *,
+    require_absolute_pair: bool = True,
+    default_relative_weeks: tuple[int, int] | None = None,
+    today: date | None = None,
+) -> tuple[date, date] | None:
+    """Resolve absolute/relative CLI options into an inclusive date range."""
+    has_absolute = options.from_date is not None or options.to_date is not None
+    has_relative = options.past_weeks is not None or options.future_weeks is not None
+
+    if has_absolute and has_relative:
+        raise typer.BadParameter(
+            "Use either --from/--to or --past-weeks/--future-weeks, not both."
+        )
+
+    if has_absolute:
+        if require_absolute_pair and (
+            options.from_date is None or options.to_date is None
+        ):
+            raise typer.BadParameter(
+                "Both --from and --to are required for absolute ranges."
+            )
+        if options.from_date is None or options.to_date is None:
+            return None
+        if options.to_date < options.from_date:
+            raise typer.BadParameter("--to cannot be before --from.")
+        return options.from_date, options.to_date
+
+    if has_relative or default_relative_weeks is not None:
+        current_day = today or date.today()
+        default_past, default_future = default_relative_weeks or (0, 0)
+        effective_past_weeks = (
+            options.past_weeks if options.past_weeks is not None else default_past
+        )
+        effective_future_weeks = (
+            options.future_weeks if options.future_weeks is not None else default_future
+        )
+        start = current_day - timedelta(weeks=effective_past_weeks)
+        end = current_day + timedelta(weeks=effective_future_weeks)
+        if end < start:
+            raise typer.BadParameter("Computed relative range is invalid.")
+        return start, end
+
+    return None
+
+
+def resolve_build_range(
+    *,
+    project_yaml: Path,
+    options: ParsedRangeOptions,
+    today: date | None = None,
+) -> tuple[date, date]:
+    """Resolve the effective build range with CLI, project, and default precedence."""
+    cli_range = resolve_cli_range(options, require_absolute_pair=True)
+    if cli_range is not None:
+        return cli_range
+
+    project_window = validate_yaml(project_yaml).history.date_window
+    if project_window.end_date is not None:
+        return project_window.start_date, project_window.end_date
+
+    current_day = today or date.today()
+    default_start = current_day - timedelta(weeks=1)
+    default_end = current_day + timedelta(weeks=1)
+    logger.warning(
+        "No CLI or project end_date provided; defaulting date range to %s through %s.",
+        default_start.isoformat(),
+        default_end.isoformat(),
+    )
+    return default_start, default_end

--- a/tests/test_date_range.py
+++ b/tests/test_date_range.py
@@ -1,0 +1,150 @@
+"""Tests for shared date range resolution."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+import typer
+
+from committee_builder.pipeline import date_range
+from committee_builder.pipeline.date_range import (
+    ParsedRangeOptions,
+    parse_cli_range_options,
+    parse_iso_date_option,
+    resolve_build_range,
+    resolve_cli_range,
+)
+
+
+def _write_project(path: Path, *, start_date: str, end_date: str | None) -> None:
+    end_date_yaml = f'"{end_date}"' if end_date is not None else "null"
+    path.write_text(
+        "\n".join(
+            [
+                'schema_version: "1.0"',
+                "metadata:",
+                '  name: "Range Test"',
+                "date_window:",
+                f'  start_date: "{start_date}"',
+                f"  end_date: {end_date_yaml}",
+                "event_type_styles:",
+                '  meeting: {label: "Meeting", color: "sky"}',
+                '  report: {label: "Report", color: "emerald"}',
+                '  decision: {label: "Decision", color: "rose"}',
+                '  milestone: {label: "Milestone", color: "amber"}',
+                '  external: {label: "External", color: "violet"}',
+                "events: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_resolve_cli_range_rejects_mixed_absolute_and_relative() -> None:
+    options = ParsedRangeOptions(
+        from_date=date(2025, 1, 1),
+        to_date=date(2025, 1, 2),
+        past_weeks=1,
+        future_weeks=None,
+    )
+
+    with pytest.raises(typer.BadParameter, match="Use either --from/--to"):
+        resolve_cli_range(options)
+
+
+def test_resolve_cli_range_rejects_partial_absolute() -> None:
+    options = ParsedRangeOptions(
+        from_date=date(2025, 1, 1),
+        to_date=None,
+        past_weeks=None,
+        future_weeks=None,
+    )
+
+    with pytest.raises(typer.BadParameter, match="Both --from and --to"):
+        resolve_cli_range(options, require_absolute_pair=True)
+
+
+def test_resolve_build_range_prefers_cli_absolute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # If CLI options are present, project-file loading should not be needed.
+    monkeypatch.setattr(
+        date_range,
+        "validate_yaml",
+        lambda _path: (_ for _ in ()).throw(AssertionError("should not load project")),
+    )
+    options = ParsedRangeOptions(
+        from_date=date(2025, 2, 1),
+        to_date=date(2025, 2, 14),
+        past_weeks=None,
+        future_weeks=None,
+    )
+
+    resolved = resolve_build_range(project_yaml=Path("unused.yaml"), options=options)
+
+    assert resolved == (date(2025, 2, 1), date(2025, 2, 14))
+
+
+def test_resolve_build_range_prefers_cli_relative(tmp_path: Path) -> None:
+    project_path = tmp_path / "committee.yaml"
+    _write_project(project_path, start_date="2020-01-01", end_date="2020-12-31")
+    options = ParsedRangeOptions(
+        from_date=None,
+        to_date=None,
+        past_weeks=2,
+        future_weeks=1,
+    )
+
+    resolved = resolve_build_range(
+        project_yaml=project_path,
+        options=options,
+        today=date(2026, 3, 24),
+    )
+
+    assert resolved == (date(2026, 3, 10), date(2026, 3, 31))
+
+
+def test_resolve_build_range_uses_project_window(tmp_path: Path) -> None:
+    project_path = tmp_path / "committee.yaml"
+    _write_project(project_path, start_date="2024-01-01", end_date="2024-03-01")
+
+    resolved = resolve_build_range(
+        project_yaml=project_path,
+        options=ParsedRangeOptions(None, None, None, None),
+    )
+
+    assert resolved == (date(2024, 1, 1), date(2024, 3, 1))
+
+
+def test_resolve_build_range_defaults_and_warns_when_project_end_missing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    project_path = tmp_path / "committee.yaml"
+    _write_project(project_path, start_date="2024-01-01", end_date=None)
+
+    resolved = resolve_build_range(
+        project_yaml=project_path,
+        options=ParsedRangeOptions(None, None, None, None),
+        today=date(2026, 3, 24),
+    )
+
+    assert resolved == (date(2026, 3, 17), date(2026, 3, 31))
+    assert "2026-03-17" in caplog.text
+    assert "2026-03-31" in caplog.text
+
+
+def test_parse_cli_range_options_rejects_invalid_iso() -> None:
+    with pytest.raises(typer.BadParameter, match="--from must be in YYYY-MM-DD"):
+        parse_cli_range_options(
+            from_date="2026/03/24",
+            to_date=None,
+            past_weeks=None,
+            future_weeks=None,
+        )
+
+
+def test_parse_iso_date_option_rejects_invalid_date() -> None:
+    with pytest.raises(typer.BadParameter, match="--to must be in YYYY-MM-DD"):
+        parse_iso_date_option("2026-13-40", option_name="--to")


### PR DESCRIPTION
### Motivation
- Eliminate duplicated date range parsing/validation logic and centralize precedence rules for CLI, project, and default ranges.
- Ensure both `build` and `indico generate` use the same mutual-exclusivity and validation behavior for absolute vs relative ranges.
- Provide a clear fallback when project `end_date` is missing and surface the computed default window via a warning with explicit dates.

### Description
- Added a new module `committee_builder/pipeline/date_range.py` that defines `ParsedRangeOptions`, `parse_iso_date_option`, `parse_cli_range_options`, `resolve_cli_range`, and `resolve_build_range` with type hints and docstrings.
- Replaced local date parsing/resolution in `committee_builder/commands/build.py` to call `parse_cli_range_options` and `resolve_build_range` so build follows CLI > project > default precedence.
- Updated `committee_builder/commands/sources.py` to use `parse_cli_range_options` and `resolve_cli_range`, moving the previous `_resolve_range` checks into the shared implementation.
- Added targeted tests `tests/test_date_range.py` that cover mixed absolute/relative rejection, partial absolute rejection, CLI absolute and relative precedence, project-window fallback, default fallback with a warning showing dates, and invalid ISO parsing.

### Testing
- Ran `python -m pytest` and all tests passed: `76 passed`.
- Ran `black --check` which initially reported files needing reformat; `black` was applied to the new files and the targeted files and subsequent `black --check` passed for the changed files.
- `flake8` was not available in the environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c23175af0483209005fce40696db00)