### PR TITLE
Orchestrate build pipeline with Indico source ingestion

### DIFF
--- a/committee_builder/pipeline/build_pipeline.py
+++ b/committee_builder/pipeline/build_pipeline.py
@@ -3,16 +3,38 @@
 from __future__ import annotations
 
 import json
+import logging
+import re
 from datetime import date
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from committee_builder.indico.client import (
+    IndicoAuthError,
+    IndicoContribution,
+    IndicoDocument,
+    IndicoMeeting,
+    fetch_meetings,
+)
+from committee_builder.indico.markdown import html_to_markdown
 from committee_builder.io.normalize import normalize_history
 from committee_builder.io.paths import default_output_html
 from committee_builder.pipeline.validate_pipeline import validate_yaml
 from committee_builder.render.markdown import render_markdown
-from committee_builder.schema.models import DateWindow, ProjectFile
+from committee_builder.schema.models import (
+    CommitteeEvent,
+    ContributionRef,
+    DateWindow,
+    DocumentRef,
+    EventType,
+    ProjectFile,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_KEY_ENV = "INDICO_API_KEY"
+DEFAULT_API_TOKEN_ENV = "INDICO_API_TOKEN"
 
 
 def _render_payload(history) -> dict:
@@ -75,6 +97,161 @@ def _apply_date_override(
     )
 
 
+def _meeting_matches_title_patterns(title: str, title_patterns: list[str]) -> bool:
+    if not title_patterns:
+        return True
+    return any(
+        re.search(pattern, title, flags=re.IGNORECASE) for pattern in title_patterns
+    )
+
+
+def _meeting_matches_title_exclusions(title: str, patterns: list[str]) -> bool:
+    return any(re.search(pattern, title, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def _contributions_with_documents(
+    contributions: list[IndicoContribution],
+) -> list[IndicoContribution]:
+    return [contribution for contribution in contributions if contribution.documents]
+
+
+def _build_document_ref(document: IndicoDocument) -> DocumentRef:
+    return DocumentRef(
+        label=document.label,
+        url=document.url,
+        talk_title=document.talk_title,
+        speaker_names=document.speaker_names,
+    )
+
+
+def _build_contribution_ref(
+    contribution: IndicoContribution, *, base_url: str
+) -> ContributionRef:
+    return ContributionRef(
+        title=contribution.title,
+        speaker_names=contribution.speaker_names,
+        documents=[
+            _build_document_ref(document) for document in contribution.documents
+        ],
+        minutes_md=html_to_markdown(contribution.minutes, base_url=base_url) or None,
+    )
+
+
+def _build_meeting_summary_md(meeting: IndicoMeeting, *, base_url: str) -> str:
+    summary_md = html_to_markdown(meeting.description, base_url=base_url) or ""
+    if meeting.url:
+        indico_link = f"[Link To Indico]({meeting.url})"
+        summary_md = (
+            f"{indico_link}\n\n{summary_md.lstrip()}"
+            if summary_md.strip()
+            else indico_link
+        )
+    return summary_md
+
+
+def _meeting_to_event(
+    meeting: IndicoMeeting, *, source_name: str, source_color: str, base_url: str
+) -> CommitteeEvent:
+    interesting_contributions = _contributions_with_documents(meeting.contributions)
+    is_interesting_meeting = bool(meeting.documents or interesting_contributions)
+
+    return CommitteeEvent(
+        id=f"{source_name}-{meeting.remote_id}",
+        type=EventType.meeting,
+        title=meeting.title,
+        date=meeting.start_datetime.date(),
+        important=is_interesting_meeting,
+        summary_md=_build_meeting_summary_md(meeting, base_url=base_url)
+        or f"Imported from source `{source_name}`.",
+        minutes_md=html_to_markdown(meeting.minutes, base_url=base_url) or None,
+        participants=meeting.participants,
+        tags=[],
+        documents=[_build_document_ref(document) for document in meeting.documents],
+        contributions=[
+            _build_contribution_ref(contribution, base_url=base_url)
+            for contribution in meeting.contributions
+        ],
+        source_name=source_name,
+        source_color=source_color,
+    )
+
+
+def _fetch_source_events(
+    history: ProjectFile,
+    *,
+    range_start: date,
+    range_end: date,
+) -> list[CommitteeEvent]:
+    source_events: list[CommitteeEvent] = []
+    for source in history.indico_category_sources:
+        try:
+            meetings = fetch_meetings(
+                source,
+                range_start,
+                range_end,
+                api_key_env=DEFAULT_API_KEY_ENV,
+                api_token_env=DEFAULT_API_TOKEN_ENV,
+            )
+        except IndicoAuthError as exc:
+            logger.warning("Skipping source '%s': %s", source.name, exc)
+            continue
+
+        for meeting in meetings:
+            if not _meeting_matches_title_patterns(meeting.title, source.title_matches):
+                continue
+            if _meeting_matches_title_exclusions(
+                meeting.title, source.title_exclude_patterns
+            ):
+                continue
+            source_events.append(
+                _meeting_to_event(
+                    meeting,
+                    source_name=source.name,
+                    source_color=source.color,
+                    base_url=source.base_url,
+                )
+            )
+    return source_events
+
+
+def _merge_events(
+    local_events: list[CommitteeEvent],
+    source_events: list[CommitteeEvent],
+) -> list[CommitteeEvent]:
+    # Duplicate strategy: local YAML events win over imported source events when IDs match.
+    merged_by_id: dict[str, CommitteeEvent] = {
+        event.id: event for event in source_events
+    }
+    for event in local_events:
+        if event.id in merged_by_id:
+            logger.warning(
+                "Keeping local event for duplicate id '%s'; skipping imported record.",
+                event.id,
+            )
+        merged_by_id[event.id] = event
+    return list(merged_by_id.values())
+
+
+def _orchestrate_history(
+    history: ProjectFile, from_date: date | None, to_date: date | None
+) -> ProjectFile:
+    overridden_history = _apply_date_override(
+        history,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    range_start = overridden_history.date_window.start_date
+    range_end = overridden_history.date_window.end_date or range_start
+
+    fetched_events = _fetch_source_events(
+        overridden_history,
+        range_start=range_start,
+        range_end=range_end,
+    )
+    merged_events = _merge_events(overridden_history.events, fetched_events)
+    return overridden_history.model_copy(update={"events": merged_events})
+
+
 def build_html(
     input_yaml: Path,
     output_path: Path | None,
@@ -84,7 +261,7 @@ def build_html(
 ) -> Path:
     """Build a standalone HTML file from the YAML input."""
     result = validate_yaml(input_yaml)
-    history = _apply_date_override(result.history, from_date=from_date, to_date=to_date)
+    history = _orchestrate_history(result.history, from_date=from_date, to_date=to_date)
     history = normalize_history(history)
     payload = _render_payload(history)
 

--- a/committee_builder/pipeline/date_range.py
+++ b/committee_builder/pipeline/date_range.py
@@ -106,7 +106,11 @@ def resolve_build_range(
     today: date | None = None,
 ) -> tuple[date, date]:
     """Resolve the effective build range with CLI, project, and default precedence."""
-    cli_range = resolve_cli_range(options, require_absolute_pair=True)
+    cli_range = resolve_cli_range(
+        options,
+        require_absolute_pair=True,
+        today=today,
+    )
     if cli_range is not None:
         return cli_range
 

--- a/tests/test_build_pipeline_orchestration.py
+++ b/tests/test_build_pipeline_orchestration.py
@@ -1,0 +1,124 @@
+"""Build pipeline orchestration tests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from committee_builder.indico.client import (
+    IndicoContribution,
+    IndicoDocument,
+    IndicoMeeting,
+)
+from committee_builder.pipeline.build_pipeline import build_html
+
+
+def test_build_fetches_transforms_and_merges_sources(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source_yaml = tmp_path / "project.yaml"
+    source_yaml.write_text(
+        """
+schema_version: "1.0"
+metadata:
+  name: "Pipeline Test"
+date_window:
+  start_date: "2025-01-01"
+  end_date: "2025-01-31"
+event_type_styles:
+  meeting: {label: "Meeting", color: "sky"}
+  report: {label: "Report", color: "emerald"}
+  decision: {label: "Decision", color: "rose"}
+  milestone: {label: "Milestone", color: "amber"}
+  external: {label: "External", color: "violet"}
+events:
+  - id: "CERN-101"
+    type: "meeting"
+    title: "Local override title"
+    date: "2025-01-15"
+    summary_md: "Keep me."
+indico_category_sources:
+  - name: "CERN"
+    category_id: 11
+    base_url: "https://indico.example.com"
+    color: "#f3d9f2"
+    title_matches: ["Weekly"]
+    title_exclude_patterns: ["Skip"]
+""",
+        encoding="utf-8",
+    )
+
+    def _fake_fetch_meetings(*_args, **_kwargs) -> list[IndicoMeeting]:
+        return [
+            IndicoMeeting(
+                remote_id="101",
+                title="Weekly Physics",
+                start_datetime=datetime(2025, 1, 10, 9, 0, 0),
+                description="<p>Agenda body</p>",
+                participants=["Alice"],
+                documents=[],
+                url="https://indico.example.com/event/101",
+                minutes="<p>Minutes body</p>",
+                contributions=[
+                    IndicoContribution(
+                        title="Detector update",
+                        speaker_names=["Bob"],
+                        documents=[
+                            IndicoDocument(
+                                label="slides.pdf",
+                                url="https://indico.example.com/files/slides.pdf",
+                            )
+                        ],
+                        minutes="<p>Talk minutes</p>",
+                    )
+                ],
+            ),
+            IndicoMeeting(
+                remote_id="102",
+                title="Skip me",
+                start_datetime=datetime(2025, 1, 10, 9, 0, 0),
+                description="<p>Should not pass filters</p>",
+                participants=[],
+                documents=[],
+                url="https://indico.example.com/event/102",
+            ),
+            IndicoMeeting(
+                remote_id="103",
+                title="Weekly Operations",
+                start_datetime=datetime(2025, 1, 11, 9, 0, 0),
+                description="<p>Included meeting</p>",
+                participants=["Charlie"],
+                documents=[],
+                url="https://indico.example.com/event/103",
+                contributions=[
+                    IndicoContribution(
+                        title="Operations report",
+                        documents=[
+                            IndicoDocument(
+                                label="ops.pdf",
+                                url="https://indico.example.com/files/ops.pdf",
+                            )
+                        ],
+                        minutes="<p>Talk minutes</p>",
+                    )
+                ],
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "committee_builder.pipeline.build_pipeline.fetch_meetings",
+        _fake_fetch_meetings,
+    )
+
+    output = build_html(source_yaml, output_path=None, overwrite=False)
+    rendered = output.read_text(encoding="utf-8")
+
+    # Imported meeting with duplicate ID should not replace the local event.
+    assert "Local override title" in rendered
+    assert "Weekly Physics" not in rendered
+    # Excluded title pattern should remove this imported event.
+    assert "Skip me" not in rendered
+    # Imported markdown conversion should be represented in serialized payload.
+    assert "Talk minutes" in rendered
+    # Source attribution should carry through for imported events.
+    assert '"source_name": "CERN"' in rendered


### PR DESCRIPTION
### Motivation
- Provide a single in-memory build flow so `build_html` can validate project YAML, resolve the effective date window, pull configured Indico meetings, convert and merge them with local events, then normalize and render the final HTML without writing an intermediate YAML.
- Reuse source-generation logic (filters, conversions, markdown conversion, source attribution) so the same behavior is available at build time as in the `indico generate` command.
- Ensure deterministic date-range resolution for tests that supply a `today=` override.

### Description
- Added orchestration helpers and source ingestion to `committee_builder/pipeline/build_pipeline.py`, including `
  _fetch_source_events`, `_meeting_to_event`, `_build_contribution_ref`, and `_merge_events` to fetch, filter, convert, and merge Indico meetings into `CommitteeEvent` records.
- Ported title include/exclude filtering and HTML→Markdown conversion via `html_to_markdown`, and mapped `IndicoDocument`/`IndicoContribution` → schema `DocumentRef`/`ContributionRef` objects so imported meetings are CommitteeEvent-compatible; source name and color are preserved on imported events.
- Implemented duplicate-ID merge strategy where imported events are loaded first and local YAML events take precedence when IDs collide (a warning is logged for duplicates).
- Replaced the previous `apply_date_override` call in `build_html` with `_orchestrate_history` so fetch/merge happens within the build flow, and updated `resolve_build_range` to propagate `today` into CLI relative range resolution.
- Added `tests/test_build_pipeline_orchestration.py` adding coverage for fetch→transform→filter→merge behavior and source attribution in the rendered HTML.

### Testing
- Ran the test suite with `python -m pytest` and `77 passed` (all tests green).
- Ran `black` formatting on modified files (succeeded); `flake8` was attempted but is not installed in the environment so that check could not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c36059c1bc8320afce7295130e311e)