### PR TITLE
Add dedicated `add minutes` command with selector and error handling

### DIFF
--- a/committee_builder/commands/add.py
+++ b/committee_builder/commands/add.py
@@ -9,6 +9,7 @@ from typing import Any
 import typer
 
 from committee_builder.commands.sources import add_source_command
+from committee_builder.commands.add_minutes import add_minutes_command
 from committee_builder.io.yaml_io import read_yaml, write_yaml
 
 logger = logging.getLogger(__name__)
@@ -65,47 +66,3 @@ def add_indico_category_command(
 ) -> None:
     """Add an Indico category source to project configuration."""
     add_source_command(config=project_config, category_url=category_url, title=title)
-
-
-def add_minutes_command(
-    project_yaml: Path = typer.Argument(
-        ..., exists=True, dir_okay=False, readable=True, help="Project YAML path."
-    ),
-    event_id: str = typer.Argument(..., help="Event id to update."),
-    minutes_file: Path = typer.Argument(
-        ...,
-        exists=True,
-        dir_okay=False,
-        readable=True,
-        help="Minutes text/markdown path.",
-    ),
-    field: str = typer.Option(
-        "minutes_md",
-        "--field",
-        help="Event markdown field to fill (minutes_md or summary_md).",
-    ),
-) -> None:
-    """Import minutes text file content into an event markdown field."""
-    if field not in {"minutes_md", "summary_md"}:
-        raise typer.BadParameter("--field must be minutes_md or summary_md.")
-
-    payload = read_yaml(project_yaml)
-    events = payload.get("events", [])
-    if not isinstance(events, list):
-        raise typer.BadParameter("`events` must be a list in the project YAML.")
-
-    minutes_text = minutes_file.read_text(encoding="utf-8").strip()
-    for event in events:
-        if isinstance(event, dict) and event.get("id") == event_id:
-            event[field] = minutes_text
-            write_yaml(project_yaml, payload)
-            logger.info(
-                "Imported %s into event '%s' (%s) in %s",
-                minutes_file,
-                event_id,
-                field,
-                project_yaml,
-            )
-            return
-
-    raise typer.BadParameter(f"Event not found: {event_id}")

--- a/committee_builder/commands/add_minutes.py
+++ b/committee_builder/commands/add_minutes.py
@@ -1,0 +1,127 @@
+"""CLI support for embedding minutes markdown into project events."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from committee_builder.io.yaml_io import read_yaml, write_yaml
+
+logger = logging.getLogger(__name__)
+
+
+def _event_matches_selector(
+    event: dict[str, Any], event_selector: str, title: str | None, date: str | None
+) -> bool:
+    """Return true when an event matches the provided selector options."""
+    if title is None:
+        return event.get("id") == event_selector
+
+    if date is None:
+        return event.get("title") == title
+
+    return event.get("title") == title and event.get("date") == date
+
+
+def _collect_matching_events(
+    events: list[Any], event_selector: str, title: str | None, date: str | None
+) -> list[dict[str, Any]]:
+    """Collect all event dicts that match selector criteria."""
+    matches: list[dict[str, Any]] = []
+    for event in events:
+        if isinstance(event, dict) and _event_matches_selector(
+            event=event,
+            event_selector=event_selector,
+            title=title,
+            date=date,
+        ):
+            matches.append(event)
+    return matches
+
+
+def add_minutes_command(
+    project_yaml: Path = typer.Argument(
+        ..., exists=True, dir_okay=False, readable=True, help="Project YAML path."
+    ),
+    event_selector: str = typer.Argument(
+        ...,
+        help=(
+            "Event selector. Defaults to matching by event id unless "
+            "--title/--date selector mode is used."
+        ),
+    ),
+    minutes_file: Path = typer.Argument(
+        ..., dir_okay=False, readable=True, help="Minutes text/markdown path."
+    ),
+    field: str = typer.Option(
+        "minutes_md",
+        "--field",
+        help="Event markdown field to fill (minutes_md or summary_md).",
+    ),
+    title: str | None = typer.Option(
+        None,
+        "--title",
+        help="Match by title (optionally combine with --date for specificity).",
+    ),
+    date: str | None = typer.Option(
+        None,
+        "--date",
+        help="When used with --title, require a specific event date (YYYY-MM-DD).",
+    ),
+) -> None:
+    """Import minutes markdown into an event markdown field."""
+    if field not in {"minutes_md", "summary_md"}:
+        raise typer.BadParameter("--field must be minutes_md or summary_md.")
+    if date is not None and title is None:
+        raise typer.BadParameter("--date can only be used together with --title.")
+
+    try:
+        minutes_text = minutes_file.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(f"Minutes file not found: {minutes_file}") from exc
+
+    payload = read_yaml(project_yaml)
+    events = payload.get("events", [])
+    if not isinstance(events, list):
+        raise typer.BadParameter("`events` must be a list in the project YAML.")
+
+    matches = _collect_matching_events(
+        events=events,
+        event_selector=event_selector,
+        title=title,
+        date=date,
+    )
+
+    if not matches:
+        if title is None:
+            raise typer.BadParameter(f"No event found for id '{event_selector}'.")
+        if date is None:
+            raise typer.BadParameter(
+                f"No event found for title '{title}'. "
+                "Pass --date when multiple events share a title."
+            )
+        raise typer.BadParameter(
+            f"No event found for title/date selector '{title}' on {date}."
+        )
+
+    if len(matches) > 1:
+        if title is None:
+            raise typer.BadParameter(
+                f"Selector '{event_selector}' matched multiple events unexpectedly."
+            )
+        raise typer.BadParameter(
+            f"Title selector '{title}' is ambiguous; add --date to disambiguate."
+        )
+
+    matches[0][field] = minutes_text
+    write_yaml(project_yaml, payload)
+    logger.info(
+        "Imported %s into event '%s' (%s) in %s",
+        minutes_file,
+        matches[0].get("id", "<unknown>"),
+        field,
+        project_yaml,
+    )

--- a/tests/test_add_minutes_cli.py
+++ b/tests/test_add_minutes_cli.py
@@ -1,0 +1,143 @@
+"""Tests for `committee add minutes` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from committee_builder.cli import app
+
+runner = CliRunner()
+
+PROJECT_YAML = """
+schema_version: "1.0"
+committee:
+  name: "Minutes CLI Test"
+  start_date: "2024-01-01"
+event_type_styles:
+  meeting: {label: "Meeting", color: "sky"}
+  report: {label: "Report", color: "emerald"}
+  decision: {label: "Decision", color: "rose"}
+  milestone: {label: "Milestone", color: "amber"}
+  external: {label: "External", color: "violet"}
+events:
+  - id: "evt-1"
+    type: "meeting"
+    title: "Kickoff"
+    date: "2024-01-10"
+    important: true
+    summary_md: "Initial"
+  - id: "evt-2"
+    type: "meeting"
+    title: "Repeat"
+    date: "2024-02-01"
+    important: false
+    summary_md: "One"
+  - id: "evt-3"
+    type: "meeting"
+    title: "Repeat"
+    date: "2024-03-01"
+    important: false
+    summary_md: "Two"
+"""
+
+
+def test_add_minutes_successful_embed() -> None:
+    with runner.isolated_filesystem():
+        project = Path("committee.yaml")
+        minutes = Path("minutes.md")
+        project.write_text(PROJECT_YAML, encoding="utf-8")
+        minutes.write_text("## Minutes\n\n- Approved", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["add", "minutes", str(project), "evt-1", str(minutes)],
+        )
+
+        assert result.exit_code == 0
+        written = yaml.safe_load(project.read_text(encoding="utf-8"))
+        assert written["events"][0]["minutes_md"] == "## Minutes\n\n- Approved"
+
+
+def test_add_minutes_missing_file() -> None:
+    with runner.isolated_filesystem():
+        project = Path("committee.yaml")
+        project.write_text(PROJECT_YAML, encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["add", "minutes", str(project), "evt-1", "missing.md"],
+        )
+
+        assert result.exit_code != 0
+        assert "Minutes file not found" in result.output
+
+
+def test_add_minutes_unknown_event_selector() -> None:
+    with runner.isolated_filesystem():
+        project = Path("committee.yaml")
+        minutes = Path("minutes.md")
+        project.write_text(PROJECT_YAML, encoding="utf-8")
+        minutes.write_text("content", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["add", "minutes", str(project), "evt-404", str(minutes)],
+        )
+
+        assert result.exit_code != 0
+        assert "No event found for id 'evt-404'" in result.output
+
+
+def test_add_minutes_ambiguous_title_selector() -> None:
+    with runner.isolated_filesystem():
+        project = Path("committee.yaml")
+        minutes = Path("minutes.md")
+        project.write_text(PROJECT_YAML, encoding="utf-8")
+        minutes.write_text("content", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            [
+                "add",
+                "minutes",
+                str(project),
+                "ignored",
+                str(minutes),
+                "--title",
+                "Repeat",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "ambiguous; add --date" in result.output
+
+
+def test_add_minutes_preserves_markdown_newlines() -> None:
+    with runner.isolated_filesystem():
+        project = Path("committee.yaml")
+        minutes = Path("minutes.md")
+        project.write_text(PROJECT_YAML, encoding="utf-8")
+        markdown = "# Header\n\nParagraph with **bold**.\n\n- a\n- b\n"
+        minutes.write_text(markdown, encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            [
+                "add",
+                "minutes",
+                str(project),
+                "unused-id",
+                str(minutes),
+                "--title",
+                "Kickoff",
+                "--date",
+                "2024-01-10",
+            ],
+        )
+
+        assert result.exit_code == 0
+        written = yaml.safe_load(project.read_text(encoding="utf-8"))
+        assert written["events"][0]["minutes_md"] == markdown


### PR DESCRIPTION
### Motivation

- Provide a dedicated CLI path to embed minutes text/markdown into project events while preserving formatting and newlines.
- Support both simple id-based selection and a title/date selector mode to allow disambiguation of events.
- Ensure YAML persistence uses the existing stable writer so ordering and key stability are preserved.
- Surface clear, actionable errors for missing files, unknown selectors, invalid option combinations, and ambiguous title-only matches.

### Description

- Added a new command module `committee_builder/commands/add_minutes.py` implementing `_event_matches_selector`, `_collect_matching_events`, and `add_minutes_command` which reads the minutes file as UTF-8 and writes the content into `minutes_md` or `summary_md`.
- The new command validates `--field` and that `--date` is only used with `--title`, returns clear `typer.BadParameter` errors when no match or multiple matches occur, and leaves markdown/newlines intact by not trimming the file content.
- Persisted changes using the existing `read_yaml` / `write_yaml` helpers from `committee_builder/io/yaml_io.py` to keep stable YAML dumping behavior.
- Wired the new command into `committee_builder/commands/add.py` and added `tests/test_add_minutes_cli.py` covering successful embed, missing file, unknown selector, ambiguous title-only selector, and markdown/newline preservation.

### Testing

- Ran the test suite with `python -m pytest` which passed: `82 passed`.
- Ran `black` on the modified files (`committee_builder/commands/add.py`, `committee_builder/commands/add_minutes.py`, `tests/test_add_minutes_cli.py`) which completed successfully.
- Attempted `flake8` but it is not available in this environment, reported as a missing tool (`/bin/bash: flake8: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c364e3a02883209ef4b8622f0b7ef0)