### PR TITLE
Update documentation and examples for single-file Indico fetch-at-build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Committee History Builder
 
-Python-first CLI for generating a single standalone committee-history HTML page from an editable YAML source file.
+Python-first CLI for generating a single standalone committee-history HTML page from a master YAML project file.
 
 ## What it does
 
-- Uses YAML as the source of truth
+- Uses one YAML project file as the source of truth (local events + Indico category sources)
 - Validates schema and semantic rules
 - Renders markdown fields (including dollar-math syntax)
+- Fetches Indico meetings during `build`, then merges imported events with local events
 - Generates a self-contained HTML file with inlined CSS, JS, and data
-- No backend and no runtime fetches required
 
 ## Install
 
@@ -28,122 +28,98 @@ pip install -e .[dev]
 
 Prerequisite: install `uv` on the machine ([docs](https://docs.astral.sh/uv/)).
 
-Run directly from a local checkout:
-
 ```bash
 uvx --from . committee --help
 uvx --from . committee build examples/committee.example.yaml --overwrite
 ```
 
-Run directly from this GitHub repo:
-
-```bash
-uvx --from git+https://github.com/gordonwatts/time-page.git committee --help
-```
-
-Run from a published package (recommended for "any computer" usage):
-
-```bash
-uvx --from committee-history-builder committee --help
-```
-
-## Gaps to close for true "any computer" `uvx` usage
-
-- Publish `committee-history-builder` to PyPI (or another index) so users can run `uvx --from committee-history-builder ...` without cloning the repo.
-- Add a CI smoke test that runs `uvx --from . committee --help` (and optionally `uvx --from committee-history-builder committee --help` after publish) to prevent packaging/entry-point regressions.
-
 ## Quickstart
 
-Create a starter file:
+1. Create a starter master project file:
 
 ```bash
-committee init data/committee.history.yaml
+committee init data/committee.project.yaml
 ```
 
-Validate data:
+2. Add an Indico category source (optional):
 
 ```bash
-committee validate data/committee.history.yaml
+committee indico add data/committee.project.yaml https://indico.example.org/category/1234/ --title cern
 ```
 
-Build standalone page:
+3. Validate the project file:
 
 ```bash
-committee build data/committee.history.yaml
+committee validate data/committee.project.yaml
+```
+
+4. Build standalone page (this step also fetches Indico meetings for the effective date window):
+
+```bash
+committee build data/committee.project.yaml --overwrite
 ```
 
 By default this writes:
 
 ```text
-data/committee.history.html
-```
-
-Override output path:
-
-```bash
-committee build data/committee.history.yaml --output dist/committee-history.html --overwrite
+data/committee.project.html
 ```
 
 ## CLI commands
 
-- `committee build INPUT_YAML [--output PATH] [--overwrite]`
-- `committee validate INPUT_YAML`
-- `committee init PATH [--force]`
-- `committee import-csv` (placeholder)
-- `committee import-md` (placeholder)
-- `committee indico add CONFIG CATEGORY_URL [--title TITLE] [--title-match PATTERN] [--title-exclude PATTERN] [--color COLOR] [--api-key-env ENV] [--api-token-env ENV]`
-- `committee indico list CONFIG`
-- `committee indico remove CONFIG NAME`
-- `committee indico generate CONFIG PROJECT_YAML --from YYYY-MM-DD --to YYYY-MM-DD [--api-key-env ENV] [--api-token-env ENV] [--output PATH]`
+- `committee build PROJECT_YAML [--output PATH] [--overwrite] [--from YYYY-MM-DD --to YYYY-MM-DD] [--past-weeks N --future-weeks M]`
+- `committee validate PROJECT_YAML`
+- `committee init PATH [--force] [--title TEXT] [--from YYYY-MM-DD] [--to YYYY-MM-DD]`
+- `committee add event PROJECT_YAML ...`
+- `committee add indico PROJECT_YAML CATEGORY_URL [--title TITLE]`
+- `committee add minutes PROJECT_YAML EVENT_ID MINUTES_PATH [--mode append|replace] [--target event|contribution] [--contribution-index N] [--contribution-title TITLE]`
+- `committee indico add PROJECT_YAML CATEGORY_URL [--title TITLE] [--title-match PATTERN] [--title-exclude PATTERN] [--color COLOR] [--api-key-env ENV] [--api-token-env ENV]`
+- `committee indico list PROJECT_YAML`
+- `committee indico remove PROJECT_YAML SOURCE_NAME`
+- `committee indico api-key BASE_URL TOKEN [--api-key-env ENV]`
+- `committee indico generate ...` *(deprecated/hidden; use `committee build`)*
 
-### Indico category workflow
+## Indico workflow (single master project file)
 
-The Indico commands use the standard HTTP export API. Public categories work without credentials; if API credentials are present they are used automatically.
-
-```bash
-pip install -e .
-```
-
-Configure a category:
+1. Add one or more category sources to the same project file:
 
 ```bash
-committee indico add cern https://indico.example.org/category/1234/ --title cern --color red
+committee indico add data/committee.project.yaml https://indico.example.org/category/1234/ --title cern --color '#FCA5A5'
+committee indico add data/committee.project.yaml https://indico.example.org/category/5678/ --title lhcb
 ```
 
-If `--color` is omitted, the CLI assigns a unique pale hex color automatically. Named CSS colors and hex values are normalized to stored `#RRGGBB` category colors.
-
-To keep only meetings whose titles match a case-insensitive regular expression, add one or more `--title-match` values. Repeat the command to accumulate filters on the same source:
+2. Optionally narrow imported meeting titles by regex:
 
 ```bash
-committee indico add cern https://indico.example.org/category/1234/ --title-match LUP
-committee indico add cern https://indico.example.org/category/1234/ --title-match Plenary
+committee indico add data/committee.project.yaml https://indico.example.org/category/1234/ --title cern --title-match LUP --title-exclude "high school"
 ```
 
-To skip meetings whose titles match a case-insensitive regular expression, add one or more `--title-exclude` values. Repeat the command to accumulate exclusion filters on the same source:
+3. Build. During build, configured sources are fetched and merged into the in-memory history before rendering:
 
 ```bash
-committee indico add cern https://indico.example.org/category/1234/ --title-exclude "high school"
-committee indico add cern https://indico.example.org/category/1234/ --title-exclude Plenary
+committee build data/committee.project.yaml --from 2024-01-01 --to 2024-12-31 --overwrite
 ```
 
-Generate meeting events into a new YAML file:
+### Date precedence and fallback behavior
 
-```bash
-committee indico generate cern data/committee.history.yaml --from 2024-01-01 --to 2024-12-31
-```
+Effective build date window precedence is:
 
-You can also generate with a relative range:
+1. CLI absolute range `--from` + `--to`
+2. CLI relative range `--past-weeks` + `--future-weeks`
+3. `date_window` in project YAML
+4. Default fallback: today ± 1 week, with a warning log
 
-```bash
-committee indico generate cern data/committee.history.yaml --past-weeks 3 --future-weeks 1
-```
+Explicit examples:
 
-See command help:
+- If YAML has `start_date: 2024-01-01` and `end_date: 2024-12-31`, then `committee build project.yaml` uses **2024-01-01 through 2024-12-31**.
+- `committee build project.yaml --from 2025-01-01 --to 2025-03-31` overrides YAML and uses **2025-01-01 through 2025-03-31**.
+- `committee build project.yaml --past-weeks 3 --future-weeks 1` uses **today - 3 weeks** through **today + 1 week**.
+- If YAML omits `end_date`, and no CLI range is supplied, build falls back to **today - 1 week** through **today + 1 week** and logs a warning.
 
-```bash
-committee --help
-committee build --help
-```
+Other warning fallbacks to know:
+
+- If an Indico source requires auth and credentials are unavailable/invalid, that source is skipped with a warning while build continues.
+- If an imported event ID collides with a local event ID, local YAML wins and the imported record is skipped with a warning.
 
 ## Logging and verbosity
 
@@ -156,59 +132,27 @@ Use global verbosity flags:
 Examples:
 
 ```bash
-committee -v validate data/committee.history.yaml
-committee -vv build data/committee.history.yaml
+committee -v validate data/committee.project.yaml
+committee -vv build data/committee.project.yaml
 ```
-
-All informational and warning output is emitted through the Python `logging` package.
 
 ## Source schema overview
 
-Top-level keys:
+Top-level keys in the master project file:
 
 - `schema_version`
-- `committee`
+- `metadata`
+- `date_window`
 - `event_type_styles`
 - `events`
+- `indico_category_sources`
 
 Markdown-capable fields:
 
-- `committee.description_md`
-- `committee.notes_md`
+- `metadata.description_md`
+- `metadata.notes_md`
 - `events[].summary_md`
-
-Events require at least:
-
-- `id`, `type`, `title`, `date`, `important`, `summary_md`
-
-Documents are records:
-
-- `{ label: string, url?: string }`
+- `events[].minutes_md`
+- `events[].contributions[].minutes_md`
 
 See a complete sample at [examples/committee.example.yaml](examples/committee.example.yaml).
-
-## Build architecture
-
-1. Load YAML
-2. Validate with Pydantic + semantic checks
-3. Normalize event order
-4. Render markdown/math to HTML
-5. Render Jinja2 template with inlined CSS/JS/data
-6. Write one standalone HTML file
-
-## Troubleshooting
-
-Validation errors:
-
-- Run `committee -vv validate <file>` for richer diagnostics.
-- Confirm required keys exist and dates are `YYYY-MM-DD`.
-
-Build fails because output exists:
-
-- Re-run with `--overwrite`.
-
-Math not rendering as expected:
-
-- Use `$...$` for inline and `$$...$$` for block expressions.
-- Ensure backslashes in YAML block strings are escaped where needed.
-

--- a/docs/indico-plan.md
+++ b/docs/indico-plan.md
@@ -1,47 +1,55 @@
-## Proposed Indico ingestion workflow (planning)
+## Indico ingestion architecture (fetch during build)
 
-This section captures the planned implementation for importing meetings from Indico categories and producing YAML files that are directly ingestable by `committee build`.
+This document describes the current architecture where Indico categories are configured in the main project YAML and fetched during `committee build`.
 
-### Required dependency and docs source
+## Master project file model
 
-- Use the **official Python package**: `indico-client` (PyPI: https://pypi.org/project/indico-client/).
-- Use the **official product documentation** for implementation details and authentication patterns: https://developer.indicodata.ai/docs/getting-started.
-- Do **not** implement direct ad-hoc HTTP calls when equivalent functionality exists in `indico-client`; the client library is the primary integration path.
+- A single project YAML is the source of truth for:
+  - project metadata
+  - date window
+  - local events
+  - `indico_category_sources`
+- Build does **not** require a separate generated meetings YAML.
+- Legacy field names are still migrated for compatibility (`committee` -> `metadata` + `date_window`, `sources` -> `indico_category_sources`).
 
-### CLI and config goals
+## Runtime flow
 
-1. Add a project config file (e.g. `.committee.indico.yaml`) to track multiple Indico category sources.
-   - User can have multiple project files - so the project file needs to be specified by the user for all project related commands.
-3. Add source management commands:
-   - `committee sources add`
-   - `committee sources list`
-   - `committee sources remove`
-4. Add meeting generation command - to output a yaml file with a meetings list:
-   - `committee sources generate project.yaml --from YYYY-MM-DD --to YYYY-MM-DD` - default output will be `project-meetings.yaml`, or `--output`.
-   - convenience ranges like `--past-weeks 3 --future-weeks 1`
+1. Load and validate project YAML.
+2. Resolve the effective date window.
+3. Fetch meetings from every configured `indico_category_sources` entry for that window.
+4. Convert remote meeting payloads to `events` (including markdown conversion and contribution/document extraction).
+5. Merge imported events with local events.
+   - Collision rule: local YAML event wins when IDs match.
+6. Render markdown and generate a standalone HTML page.
 
-### Authentication approach
+## Date precedence (with explicit examples)
 
-- Support private feeds by reading credentials from environment variables or a .env file in the home directory.
-- Config stores env-var names (for example `INDICO_API_KEY`, `INDICO_API_TOKEN`) rather than raw secrets.
-- The command resolves env vars at runtime and initializes `indico-client` with those credentials.
+Effective build date window precedence:
 
-### Output contract
+1. CLI absolute range `--from` + `--to`
+2. CLI relative range `--past-weeks` + `--future-weeks`
+3. Project file `date_window.start_date` + `date_window.end_date`
+4. Default fallback when no explicit end date exists: today ± 1 week
 
-- Generated YAML (`project-meetings.yaml`) must validate against existing schema and be directly consumable by:
-  - `committee validate <generated.yaml>`
-  - `committee build <generated.yaml>`
-- Event mapping should be deterministic:
-  - stable generated IDs (`<source-name>-<remote-id>`)
-  - normalized date handling
-  - sorted output for low-noise diffs.
+Examples:
 
-### High-level implementation phases
+- `committee build project.yaml` with YAML window `2024-01-01`..`2024-12-31` uses **2024-01-01** to **2024-12-31**.
+- `committee build project.yaml --from 2025-01-01 --to 2025-03-31` uses **2025-01-01** to **2025-03-31**.
+- `committee build project.yaml --past-weeks 2 --future-weeks 4` uses **today - 2 weeks** to **today + 4 weeks**.
+- If YAML has only `start_date` and no `end_date`, `committee build project.yaml` falls back to **today - 1 week** through **today + 1 week**.
 
-1. Add typed config models and YAML IO support for Indico source configuration.
-2. Implement source-management CLI commands.
-3. Implement Indico integration layer using `indico-client`.
-4. Implement transformation from fetched meetings to `CommitteeHistory` schema events.
-5. Implement `meetings generate` command with absolute and relative date range options.
-6. Add pytest coverage for config operations, API client mocking, and generated YAML compatibility.
-7. Update README usage examples end-to-end.
+## Warning fallback behavior
+
+The build pipeline prefers continuing with warnings when possible:
+
+- Missing `date_window.end_date` (and no CLI overrides): logs a warning and uses today ± 1 week.
+- Auth-required source without usable credentials: logs warning, skips that source, continues.
+- Imported event ID duplicates local event ID: logs warning, keeps local event.
+
+These warnings are visible by default and are easier to inspect with `committee -v` or `committee -vv`.
+
+## Command implications
+
+- `committee build <project.yaml>` is the primary ingestion/build command.
+- `committee indico generate` is deprecated; use build-time fetch instead.
+- `committee indico add|list|remove|api-key` manage source metadata and credentials.

--- a/examples/committee.example.yaml
+++ b/examples/committee.example.yaml
@@ -1,18 +1,23 @@
 schema_version: "1.0"
-committee:
+metadata:
   name: "Committee History Viewer"
-  subtitle: "Static single-page timeline for meetings, reports, and conclusions"
+  subtitle: "Single project file with local entries + Indico sources"
   description_md: |
-    This is a Python-generated, standalone timeline page.
-    All data is embedded into the output HTML file.
-  start_date: "2023-01-01"
-  end_date: "2024-12-31"
+    This project uses one master YAML file.
+
+    - Local committee records live in `events`.
+    - Indico categories are configured in `indico_category_sources`.
+    - `committee build` fetches meetings for those sources during build.
   notes_md: |
-    Use markdown with inline math like $E=mc^2$ and blocks like:
+    Markdown and math are supported:
 
     $$
-    \int_0^1 x^2 dx = 1/3
+    \int_0^1 x^2 dx = \frac{1}{3}
     $$
+
+date_window:
+  start_date: "2024-01-01"
+  end_date: "2024-12-31"
 
 event_type_styles:
   meeting:
@@ -31,55 +36,60 @@ event_type_styles:
     label: "External"
     color: "violet"
 
+indico_category_sources:
+  - name: "cern-lhcc"
+    base_url: "https://indico.cern.ch"
+    category_id: 1234
+    color: "#FCA5A5"
+    title_matches: ["LHCC", "plenary"]
+    title_exclude_patterns: ["high school"]
+  - name: "cern-upgrade"
+    base_url: "https://indico.cern.ch"
+    category_id: 5678
+    color: "#93C5FD"
+
 events:
-  - id: "evt-1"
+  - id: "evt-001"
     type: "meeting"
     title: "Kickoff Meeting"
-    date: "2023-01-12"
+    date: "2024-01-12"
     important: true
     short_label: "Kickoff"
     summary_md: |
       # Kickoff Meeting
 
-      The committee established scope and cadence.
+      Scope and cadence were established.
 
       - Monthly meetings
       - Shared repository
+    minutes_md: |
+      ## Notes
+
+      Agenda and decisions were reviewed.
     participants: ["A. Smith", "B. Jones", "C. Lee"]
     tags: ["scope", "kickoff", "planning"]
     documents:
       - label: "agenda.pdf"
       - label: "minutes.md"
+    contributions:
+      - title: "Detector status update"
+        speaker_names: ["B. Jones"]
+        minutes_md: |
+          - Shared updated calibration schedule.
+          - Requested focused follow-up next week.
+        documents:
+          - label: "status-slides.pdf"
+            url: "https://example.org/status-slides.pdf"
 
-  - id: "evt-2"
+  - id: "evt-002"
     type: "report"
     title: "Initial Findings Memo"
-    date: "2023-03-25"
-    important: false
+    date: "2024-03-25"
     summary_md: |
       ## Memo Summary
 
-      Key theme: **process ambiguity** was slowing progress.
+      Key theme: **process ambiguity** slowed progress.
     participants: ["Editorial subgroup"]
     tags: ["report", "findings"]
     documents:
       - label: "initial-findings.pdf"
-
-  - id: "evt-3"
-    type: "decision"
-    title: "Decision on Review Criteria"
-    date: "2023-05-18"
-    important: true
-    short_label: "Criteria Adopted"
-    summary_md: |
-      ## Decision
-
-      Adopted criteria:
-
-      1. Transparency
-      2. Timeliness
-      3. Documentation quality
-    participants: ["Full committee"]
-    tags: ["decision", "criteria"]
-    documents:
-      - label: "criteria-v2.md"

--- a/scripts/Invoke-CommitteeBuild.ps1
+++ b/scripts/Invoke-CommitteeBuild.ps1
@@ -23,42 +23,20 @@ else {
     $Config
 }
 
-$configDirectory = Split-Path -Parent $configPath
-$configStem = [System.IO.Path]::GetFileNameWithoutExtension($configPath)
-$generatedYaml = if ([string]::IsNullOrEmpty($configDirectory)) {
-    "$configStem-generated.yaml"
-}
-else {
-    Join-Path $configDirectory "$configStem-generated.yaml"
-}
-
-$builtHtml = [System.IO.Path]::ChangeExtension($generatedYaml, '.html')
-
-$generateArgs = @(
-    '--from', 'git+https://github.com/gordonwatts/time-page.git',
-    'committee', 'indico', 'generate',
-    $Config,
-    '--from', $fromDateIso,
-    '--to', $toDateIso
-)
+$builtHtml = [System.IO.Path]::ChangeExtension($configPath, '.html')
 
 $buildArgs = @(
     '--from', 'git+https://github.com/gordonwatts/time-page.git',
     'committee', 'build',
-    $generatedYaml
+    $configPath,
+    '--from', $fromDateIso,
+    '--to', $toDateIso,
+    '--overwrite'
 )
 
-$generateCmd = "uvx $($generateArgs -join ' ')"
 $buildCmd = "uvx $($buildArgs -join ' ')"
 
 $null = Get-Command uvx -ErrorAction Stop
-
-if ($PSCmdlet.ShouldProcess($generateCmd, "Invoke")) {
-    & uvx @generateArgs
-    if ($LASTEXITCODE -ne 0) {
-        throw "Generate command failed with exit code $LASTEXITCODE"
-    }
-}
 
 if ($PSCmdlet.ShouldProcess($buildCmd, "Invoke")) {
     & uvx @buildArgs
@@ -66,3 +44,5 @@ if ($PSCmdlet.ShouldProcess($buildCmd, "Invoke")) {
         throw "Build command failed with exit code $LASTEXITCODE"
     }
 }
+
+Write-Verbose "Built HTML: $builtHtml"


### PR DESCRIPTION
### Motivation

- Consolidate the project model to a single master YAML file that contains both local events and `indico_category_sources` so `committee build` can fetch and merge Indico meetings at build time.
- Make the user workflow and CLI surface clearer by updating quickstart, examples, and the planned Indico architecture to reflect fetch-during-build behavior and simplified invocation.
- Clarify date-range precedence and explicit fallback/warning behavior so users understand which date window is used and what warnings mean.

### Description

- Rewrote `README.md` to document the single master project YAML workflow, updated quickstart steps, revised CLI command list, and added explicit `--from/--to` vs relative ranges precedence examples and warning fallback behavior.
- Replaced `examples/committee.example.yaml` with a master-project-style example using `metadata` + `date_window`, embedded markdown/math, `indico_category_sources`, and richer local `events` (minutes, contributions, documents).
- Replaced `docs/indico-plan.md` with `docs/indico-plan.md` describing the fetch-during-build architecture, runtime flow, date precedence examples, and warning fallback semantics.
- Updated `scripts/Invoke-CommitteeBuild.ps1` to call `committee build` directly with computed `--from`/`--to` and `--overwrite`, removing the prior generate-then-build flow and simplifying invocation.

### Testing

- Ran tests with `python -m pytest` (via fallback launcher when `.venv/bin/python` exists), resulting in `82 passed` tests.
- Attempted `black --check .` which reported files that would be reformatted (7 files) indicating repository formatting drift unrelated to these docs-only changes.
- `flake8 .` was not available in the environment (`flake8: command not found`).
- Confirmed no leftover `test-scratch/` directory after tests (not present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c369784868832086ef5073fb4929c7)