### PR TITLE
Include date in generated add-event titles

### DIFF
--- a/committee_builder/commands/add.py
+++ b/committee_builder/commands/add.py
@@ -19,7 +19,7 @@ def add_event_command(
     project_yaml: Path = typer.Argument(
         ..., exists=True, dir_okay=False, readable=True, help="Project YAML path."
     ),
-    title: str = typer.Option(..., "--title", help="Event title."),
+    title: str | None = typer.Option(None, "--title", help="Event title."),
     date: str = typer.Option(..., "--date", help="Event date in YYYY-MM-DD."),
     event_id: str | None = typer.Option(None, "--id", help="Optional event id."),
     event_type: str = typer.Option("meeting", "--type", help="Event type."),
@@ -34,10 +34,13 @@ def add_event_command(
         raise typer.BadParameter("`events` must be a list in the project YAML.")
 
     new_event_id = event_id or f"evt-{len(events) + 1:03d}"
+    event_title = title.strip() if title is not None else ""
+    if not event_title:
+        event_title = f"{date} - Event Title"
     event_doc: dict[str, Any] = {
         "id": new_event_id,
         "type": event_type,
-        "title": title,
+        "title": event_title,
         "date": date,
         "important": False,
         "summary_md": summary_md,

--- a/tests/test_add_event_cli.py
+++ b/tests/test_add_event_cli.py
@@ -1,0 +1,63 @@
+"""Tests for `committee add event` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from committee_builder.cli import app
+
+runner = CliRunner()
+
+PROJECT_YAML = """
+schema_version: "1.0"
+metadata:
+  name: "Add Event CLI Test"
+date_window:
+  start_date: "2024-01-01"
+  end_date: "2024-12-31"
+event_type_styles:
+  meeting: {label: "Meeting", color: "sky"}
+  report: {label: "Report", color: "emerald"}
+  decision: {label: "Decision", color: "rose"}
+  milestone: {label: "Milestone", color: "amber"}
+  external: {label: "External", color: "violet"}
+events: []
+"""
+
+
+def test_add_event_uses_date_in_generated_title_when_title_omitted() -> None:
+    with runner.isolated_filesystem():
+        project = Path("committee.yaml")
+        project.write_text(PROJECT_YAML, encoding="utf-8")
+
+        result = runner.invoke(app, ["add", "event", str(project), "--date", "2024-04-15"])
+
+        assert result.exit_code == 0
+        written = yaml.safe_load(project.read_text(encoding="utf-8"))
+        assert written["events"][0]["title"] == "2024-04-15 - Event Title"
+
+
+def test_add_event_preserves_explicit_title() -> None:
+    with runner.isolated_filesystem():
+        project = Path("committee.yaml")
+        project.write_text(PROJECT_YAML, encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            [
+                "add",
+                "event",
+                str(project),
+                "--date",
+                "2024-04-15",
+                "--title",
+                "Detector Readout Review",
+            ],
+        )
+
+        assert result.exit_code == 0
+        written = yaml.safe_load(project.read_text(encoding="utf-8"))
+        assert written["events"][0]["title"] == "Detector Readout Review"


### PR DESCRIPTION
- make `committee add event --title` optional
- generate fallback event titles as `YYYY-MM-DD - Event Title` when no title is provided
- add CLI tests covering generated and explicit titles

Fixes #46