### PR TITLE
Use --force for build output overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Prerequisite: install `uv` on the machine ([docs](https://docs.astral.sh/uv/)).
 
 ```bash
 uvx --from . committee --help
-uvx --from . committee build examples/committee.example.yaml --overwrite
+uvx --from . committee build examples/committee.example.yaml --force
 ```
 
 ## Quickstart
@@ -56,7 +56,7 @@ committee validate data/committee.project.yaml
 4. Build standalone page (this step also fetches Indico meetings for the effective date window):
 
 ```bash
-committee build data/committee.project.yaml --overwrite
+committee build data/committee.project.yaml --force
 ```
 
 By default this writes:
@@ -67,7 +67,7 @@ data/committee.project.html
 
 ## CLI commands
 
-- `committee build PROJECT_YAML [--output PATH] [--overwrite] [--from DATE_EXPR --to DATE_EXPR] [--past-weeks N --future-weeks M]`
+- `committee build PROJECT_YAML [--output PATH] [--force] [--from DATE_EXPR --to DATE_EXPR] [--past-weeks N --future-weeks M]`
 - `committee validate PROJECT_YAML`
 - `committee init PATH [--force] [--title TEXT] [--from DATE_EXPR] [--to DATE_EXPR]`
 - `committee add event PROJECT_YAML ...`
@@ -96,8 +96,8 @@ committee indico add data/committee.project.yaml https://indico.example.org/cate
 3. Build. During build, configured sources are fetched and merged into the in-memory history before rendering:
 
 ```bash
-committee build data/committee.project.yaml --from 2024-01-01 --to 2024-12-31 --overwrite
-committee build data/committee.project.yaml --from -3w --to now --overwrite
+committee build data/committee.project.yaml --from 2024-01-01 --to 2024-12-31 --force
+committee build data/committee.project.yaml --from -3w --to now --force
 ```
 
 Use `committee build` with `--from/--to` (or `--past-weeks/--future-weeks`) whenever you need date overrides for Indico ingestion. `--from` and `--to` accept ISO dates, natural-language expressions that `dateparser` understands, and short relative forms such as `now`, `-3d`, `+2w`, `-1m`, and `-1y`.
@@ -109,7 +109,7 @@ Effective build date window precedence is:
 1. CLI absolute range `--from` + `--to`
 2. CLI relative range `--past-weeks` + `--future-weeks`
 3. `date_window` in project YAML
-4. Default fallback: today ± 1 week, with a warning log
+4. Default fallback: today Â± 1 week, with a warning log
 
 Explicit examples:
 

--- a/committee_builder/commands/build.py
+++ b/committee_builder/commands/build.py
@@ -31,8 +31,8 @@ def build_command(
     ),
     overwrite: bool = typer.Option(
         False,
-        "--overwrite",
-        help="Allow overwriting an existing output file.",
+        "--force",
+        help="Overwrite an existing output file.",
     ),
     from_date: str | None = typer.Option(
         None, "--from", help="Override start date (ISO, now, -3d, +2w, etc.)."

--- a/committee_builder/pipeline/build_pipeline.py
+++ b/committee_builder/pipeline/build_pipeline.py
@@ -287,7 +287,9 @@ def build_html(
 
     target = output_path if output_path is not None else default_output_html(input_yaml)
     if target.exists() and not overwrite:
-        raise FileExistsError(f"Output file exists: {target} (use --force)")
+        raise FileExistsError(
+            f"Output file exists: {target} (set overwrite=True or use --force)"
+        )
 
     css, js, env = _load_template_assets()
     template = env.get_template("template.html.j2")

--- a/committee_builder/pipeline/build_pipeline.py
+++ b/committee_builder/pipeline/build_pipeline.py
@@ -287,7 +287,7 @@ def build_html(
 
     target = output_path if output_path is not None else default_output_html(input_yaml)
     if target.exists() and not overwrite:
-        raise FileExistsError(f"Output file exists: {target} (use --overwrite)")
+        raise FileExistsError(f"Output file exists: {target} (use --force)")
 
     css, js, env = _load_template_assets()
     template = env.get_template("template.html.j2")

--- a/scripts/Invoke-CommitteeBuild.ps1
+++ b/scripts/Invoke-CommitteeBuild.ps1
@@ -31,7 +31,7 @@ $buildArgs = @(
     $configPath,
     '--from', $fromDateIso,
     '--to', $toDateIso,
-    '--overwrite'
+    '--force'
 )
 
 $buildCmd = "uvx $($buildArgs -join ' ')"

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -137,3 +137,18 @@ def test_build_adds_yaml_suffix_when_omitted() -> None:
 
         assert result.exit_code == 0
         assert Path("committee.html").exists()
+
+
+def test_build_force_overwrites_existing_output() -> None:
+    with runner.isolated_filesystem():
+        src = Path("committee.yaml")
+        src.write_text(SAMPLE, encoding="utf-8")
+        out = Path("committee.html")
+        out.write_text("old output", encoding="utf-8")
+
+        result = runner.invoke(app, ["build", str(src), "--force"])
+
+        assert result.exit_code == 0
+        text = out.read_text(encoding="utf-8")
+        assert "committee-data" in text
+        assert "old output" not in text

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -22,7 +22,7 @@ def test_build_help_has_range_and_output_options() -> None:
     result = runner.invoke(app, ["build", "--help"])
     assert result.exit_code == 0
     assert "--output" in result.stdout
-    assert "--overwrite" in result.stdout
+    assert "--force" in result.stdout
     assert "--from" in result.stdout
     assert "--to" in result.stdout
     assert "--past-weeks" in result.stdout


### PR DESCRIPTION
Fixes #54

- rename the `committee build` overwrite flag from `--overwrite` to `--force` so it matches `committee init`
- update the build overwrite error message, README examples, help coverage, and the PowerShell helper script to use `--force`
- add CLI coverage for `build --force` overwriting an existing output file

Validation:
- `./.venv/Scripts/python.exe -m pytest` is currently blocked because the repo virtualenv does not have `pytest` installed, and bootstrapping it with `ensurepip` hit a temp-directory permission error in this environment
- direct CLI smoke checks passed for `committee build --help`, `committee build` failing with `use --force`, and `committee build --force` successfully replacing an existing HTML file

Remaining risk / follow-up:
- low risk; the change is limited to the public build flag and related user-facing docs/messages
